### PR TITLE
feat: refactor of notifications (CMC-1442) 3/4

### DIFF
--- a/src/main/resources/camunda/acknowledge_claim.bpmn
+++ b/src/main/resources/camunda/acknowledge_claim.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.3">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="ACKNOWLEDGE_CLAIM_PROCESS_ID" isExecutable="true">
     <bpmn:serviceTask id="AcknowledgeClaimNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -14,7 +14,7 @@
       <bpmn:outgoing>Flow_116h4jn</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1dvrj2w" messageRef="Message_07sm7e9" />
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_06qap0k" sourceRef="AcknowledgeClaimNotifyApplicantSolicitor1" targetRef="Activity_0471ljk" />
+    <bpmn:sequenceFlow id="Flow_06qap0k" sourceRef="AcknowledgeClaimNotifyApplicantSolicitor1" targetRef="AcknowledgeClaimNotifyRespondentSolicitor1CC" />
     <bpmn:endEvent id="Event_1h61h5s">
       <bpmn:incoming>Flow_0x2wz2v</bpmn:incoming>
     </bpmn:endEvent>
@@ -26,7 +26,7 @@
         </camunda:properties>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_06qap0k</bpmn:incoming>
+      <bpmn:incoming>Flow_0as63xn</bpmn:incoming>
       <bpmn:outgoing>Flow_0x2wz2v</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_0dikpym" sourceRef="AcknowledgeClaimGenerateAcknowledgementOfClaim" targetRef="AcknowledgeClaimNotifyApplicantSolicitor1" />
@@ -57,49 +57,54 @@
     <bpmn:sequenceFlow id="Flow_1y0ic2q" sourceRef="Event_0kza4it" targetRef="Event_1n2x861" />
     <bpmn:sequenceFlow id="Flow_116h4jn" sourceRef="Event_0vk0w99" targetRef="Activity_15x2r24" />
     <bpmn:sequenceFlow id="Flow_1a5jscb" sourceRef="Activity_15x2r24" targetRef="AcknowledgeClaimGenerateAcknowledgementOfClaim" />
+    <bpmn:serviceTask id="AcknowledgeClaimNotifyRespondentSolicitor1CC" name="Notify respondent solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_ACKNOWLEDGEMENT_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_06qap0k</bpmn:incoming>
+      <bpmn:outgoing>Flow_0as63xn</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0as63xn" sourceRef="AcknowledgeClaimNotifyRespondentSolicitor1CC" targetRef="Activity_0471ljk" />
   </bpmn:process>
   <bpmn:error id="Error_0lou1w7" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmn:message id="Message_07sm7e9" name="ACKNOWLEDGE_CLAIM" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ACKNOWLEDGE_CLAIM_PROCESS_ID">
-      <bpmndi:BPMNEdge id="Flow_0dikpym_di" bpmnElement="Flow_0dikpym">
-        <di:waypoint x="480" y="207" />
-        <di:waypoint x="520" y="207" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0x2wz2v_di" bpmnElement="Flow_0x2wz2v">
-        <di:waypoint x="770" y="207" />
-        <di:waypoint x="822" y="207" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06qap0k_di" bpmnElement="Flow_06qap0k">
-        <di:waypoint x="620" y="207" />
-        <di:waypoint x="670" y="207" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1y0ic2q_di" bpmnElement="Flow_1y0ic2q">
-        <di:waypoint x="280" y="149" />
-        <di:waypoint x="280" y="115" />
+      <bpmndi:BPMNEdge id="Flow_1a5jscb_di" bpmnElement="Flow_1a5jscb">
+        <di:waypoint x="330" y="207" />
+        <di:waypoint x="380" y="207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_116h4jn_di" bpmnElement="Flow_116h4jn">
         <di:waypoint x="188" y="210" />
         <di:waypoint x="230" y="210" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1a5jscb_di" bpmnElement="Flow_1a5jscb">
-        <di:waypoint x="330" y="207" />
-        <di:waypoint x="380" y="207" />
+      <bpmndi:BPMNEdge id="Flow_1y0ic2q_di" bpmnElement="Flow_1y0ic2q">
+        <di:waypoint x="280" y="149" />
+        <di:waypoint x="280" y="115" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="AcknowledgeClaimNotifyApplicantSolicitor1">
-        <dc:Bounds x="520" y="167" width="100" height="80" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0dikpym_di" bpmnElement="Flow_0dikpym">
+        <di:waypoint x="480" y="207" />
+        <di:waypoint x="510" y="207" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x2wz2v_di" bpmnElement="Flow_0x2wz2v">
+        <di:waypoint x="880" y="207" />
+        <di:waypoint x="912" y="207" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06qap0k_di" bpmnElement="Flow_06qap0k">
+        <di:waypoint x="610" y="207" />
+        <di:waypoint x="650" y="207" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0as63xn_di" bpmnElement="Flow_0as63xn">
+        <di:waypoint x="750" y="207" />
+        <di:waypoint x="780" y="207" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0vk0w99_di" bpmnElement="Event_0vk0w99">
         <dc:Bounds x="152" y="192" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="235" width="24" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1h61h5s_di" bpmnElement="Event_1h61h5s">
-        <dc:Bounds x="822" y="189" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1j68eid_di" bpmnElement="Activity_0471ljk">
-        <dc:Bounds x="670" y="167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0phbsqq_di" bpmnElement="AcknowledgeClaimGenerateAcknowledgementOfClaim">
         <dc:Bounds x="380" y="167" width="100" height="80" />
@@ -109,6 +114,18 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1n2x861_di" bpmnElement="Event_1n2x861">
         <dc:Bounds x="262" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1h61h5s_di" bpmnElement="Event_1h61h5s">
+        <dc:Bounds x="912" y="189" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1j68eid_di" bpmnElement="Activity_0471ljk">
+        <dc:Bounds x="780" y="167" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="AcknowledgeClaimNotifyApplicantSolicitor1">
+        <dc:Bounds x="510" y="167" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xyweyi_di" bpmnElement="AcknowledgeClaimNotifyRespondentSolicitor1CC">
+        <dc:Bounds x="650" y="167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0kza4it_di" bpmnElement="Event_0kza4it">
         <dc:Bounds x="262" y="149" width="36" height="36" />

--- a/src/main/resources/camunda/add_defendant_litigation_friend.bpmn
+++ b/src/main/resources/camunda/add_defendant_litigation_friend.bpmn
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1lfk8so" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
-  <bpmn:process id="Process_1vrxz02" isExecutable="true">
-    <bpmn:startEvent id="Event_14vi3oh" name="Start">
+  <bpmn:process id="ADD_DEFENDANT_LITIGATION_FRIEND" isExecutable="true">
+    <bpmn:startEvent id="Event_0kkfooq" name="Start">
       <bpmn:outgoing>Flow_0h29dto</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1eis14z" messageRef="Message_0zm9rfj" />
     </bpmn:startEvent>
@@ -33,7 +33,7 @@
       <bpmn:outgoing>Flow_000871z</bpmn:outgoing>
       <bpmn:errorEventDefinition id="ErrorEventDefinition_1a4cujn" />
     </bpmn:boundaryEvent>
-    <bpmn:sequenceFlow id="Flow_0h29dto" sourceRef="Event_14vi3oh" targetRef="Activity_18synbb" />
+    <bpmn:sequenceFlow id="Flow_0h29dto" sourceRef="Event_0kkfooq" targetRef="Activity_18synbb" />
     <bpmn:sequenceFlow id="Flow_1kz0hux" sourceRef="Activity_18synbb" targetRef="LitigationFriendAddedNotifyApplicantSolicitor1" />
     <bpmn:sequenceFlow id="Flow_000871z" sourceRef="Event_152jcow" targetRef="Event_0vj0pv5" />
     <bpmn:sequenceFlow id="Flow_0hzoh57" sourceRef="Activity_1tqimyo" targetRef="Event_0i8j65q" />
@@ -60,32 +60,32 @@
   </bpmn:process>
   <bpmn:message id="Message_0zm9rfj" name="ADD_DEFENDANT_LITIGATION_FRIEND" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1vrxz02">
-      <bpmndi:BPMNEdge id="Flow_0h29dto_di" bpmnElement="Flow_0h29dto">
-        <di:waypoint x="188" y="220" />
-        <di:waypoint x="230" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1kz0hux_di" bpmnElement="Flow_1kz0hux">
-        <di:waypoint x="330" y="217" />
-        <di:waypoint x="370" y="217" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_000871z_di" bpmnElement="Flow_000871z">
-        <di:waypoint x="280" y="159" />
-        <di:waypoint x="280" y="125" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0hzoh57_di" bpmnElement="Flow_0hzoh57">
-        <di:waypoint x="740" y="217" />
-        <di:waypoint x="772" y="217" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="ADD_DEFENDANT_LITIGATION_FRIEND">
+      <bpmndi:BPMNEdge id="Flow_1a2p59a_di" bpmnElement="Flow_1a2p59a">
+        <di:waypoint x="600" y="220" />
+        <di:waypoint x="640" y="220" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17ysgkl_di" bpmnElement="Flow_17ysgkl">
         <di:waypoint x="470" y="217" />
         <di:waypoint x="500" y="217" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1a2p59a_di" bpmnElement="Flow_1a2p59a">
-        <di:waypoint x="600" y="220" />
-        <di:waypoint x="640" y="220" />
+      <bpmndi:BPMNEdge id="Flow_0hzoh57_di" bpmnElement="Flow_0hzoh57">
+        <di:waypoint x="740" y="217" />
+        <di:waypoint x="772" y="217" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_14vi3oh_di" bpmnElement="Event_14vi3oh">
+      <bpmndi:BPMNEdge id="Flow_000871z_di" bpmnElement="Flow_000871z">
+        <di:waypoint x="280" y="159" />
+        <di:waypoint x="280" y="125" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kz0hux_di" bpmnElement="Flow_1kz0hux">
+        <di:waypoint x="330" y="217" />
+        <di:waypoint x="370" y="217" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0h29dto_di" bpmnElement="Flow_0h29dto">
+        <di:waypoint x="188" y="220" />
+        <di:waypoint x="230" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_14vi3oh_di" bpmnElement="Event_0kkfooq">
         <dc:Bounds x="152" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="158" y="245" width="24" height="14" />
@@ -97,11 +97,11 @@
       <bpmndi:BPMNShape id="Event_0vj0pv5_di" bpmnElement="Event_0vj0pv5">
         <dc:Bounds x="262" y="89" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0i8j65q_di" bpmnElement="Event_0i8j65q">
-        <dc:Bounds x="772" y="199" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1tqimyo_di" bpmnElement="Activity_1tqimyo">
         <dc:Bounds x="640" y="177" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0i8j65q_di" bpmnElement="Event_0i8j65q">
+        <dc:Bounds x="772" y="199" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0kyj41c_di" bpmnElement="LitigationFriendAddedNotifyApplicantSolicitor1">
         <dc:Bounds x="370" y="177" width="100" height="80" />

--- a/src/main/resources/camunda/add_defendant_litigation_friend.bpmn
+++ b/src/main/resources/camunda/add_defendant_litigation_friend.bpmn
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1lfk8so" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
+  <bpmn:process id="Process_1vrxz02" isExecutable="true">
+    <bpmn:startEvent id="Event_14vi3oh" name="Start">
+      <bpmn:outgoing>Flow_0h29dto</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1eis14z" messageRef="Message_0zm9rfj" />
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Activity_18synbb" name="Start Business Process" calledElement="StartBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0h29dto</bpmn:incoming>
+      <bpmn:outgoing>Flow_1kz0hux</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0vj0pv5">
+      <bpmn:incoming>Flow_000871z</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:callActivity id="Activity_1tqimyo" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="variables" value="all" />
+        </camunda:properties>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1a2p59a</bpmn:incoming>
+      <bpmn:outgoing>Flow_0hzoh57</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0i8j65q">
+      <bpmn:incoming>Flow_0hzoh57</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_152jcow" name="Abort" attachedToRef="Activity_18synbb">
+      <bpmn:outgoing>Flow_000871z</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1a4cujn" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0h29dto" sourceRef="Event_14vi3oh" targetRef="Activity_18synbb" />
+    <bpmn:sequenceFlow id="Flow_1kz0hux" sourceRef="Activity_18synbb" targetRef="LitigationFriendAddedNotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_000871z" sourceRef="Event_152jcow" targetRef="Event_0vj0pv5" />
+    <bpmn:sequenceFlow id="Flow_0hzoh57" sourceRef="Activity_1tqimyo" targetRef="Event_0i8j65q" />
+    <bpmn:serviceTask id="LitigationFriendAddedNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_LITIGATION_FRIEND_ADDED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1kz0hux</bpmn:incoming>
+      <bpmn:outgoing>Flow_17ysgkl</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_17ysgkl" sourceRef="LitigationFriendAddedNotifyApplicantSolicitor1" targetRef="LitigationFriendAddedNotifyRespondentSolicitor1" />
+    <bpmn:serviceTask id="LitigationFriendAddedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_LITIGATION_FRIEND_ADDED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_17ysgkl</bpmn:incoming>
+      <bpmn:outgoing>Flow_1a2p59a</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1a2p59a" sourceRef="LitigationFriendAddedNotifyRespondentSolicitor1" targetRef="Activity_1tqimyo" />
+  </bpmn:process>
+  <bpmn:message id="Message_0zm9rfj" name="ADD_DEFENDANT_LITIGATION_FRIEND" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1vrxz02">
+      <bpmndi:BPMNEdge id="Flow_0h29dto_di" bpmnElement="Flow_0h29dto">
+        <di:waypoint x="188" y="220" />
+        <di:waypoint x="230" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kz0hux_di" bpmnElement="Flow_1kz0hux">
+        <di:waypoint x="330" y="217" />
+        <di:waypoint x="370" y="217" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_000871z_di" bpmnElement="Flow_000871z">
+        <di:waypoint x="280" y="159" />
+        <di:waypoint x="280" y="125" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0hzoh57_di" bpmnElement="Flow_0hzoh57">
+        <di:waypoint x="740" y="217" />
+        <di:waypoint x="772" y="217" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17ysgkl_di" bpmnElement="Flow_17ysgkl">
+        <di:waypoint x="470" y="217" />
+        <di:waypoint x="500" y="217" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1a2p59a_di" bpmnElement="Flow_1a2p59a">
+        <di:waypoint x="600" y="220" />
+        <di:waypoint x="640" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_14vi3oh_di" bpmnElement="Event_14vi3oh">
+        <dc:Bounds x="152" y="202" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="245" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18synbb_di" bpmnElement="Activity_18synbb">
+        <dc:Bounds x="230" y="177" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vj0pv5_di" bpmnElement="Event_0vj0pv5">
+        <dc:Bounds x="262" y="89" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0i8j65q_di" bpmnElement="Event_0i8j65q">
+        <dc:Bounds x="772" y="199" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1tqimyo_di" bpmnElement="Activity_1tqimyo">
+        <dc:Bounds x="640" y="177" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kyj41c_di" bpmnElement="LitigationFriendAddedNotifyApplicantSolicitor1">
+        <dc:Bounds x="370" y="177" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1eqzvl4_di" bpmnElement="LitigationFriendAddedNotifyRespondentSolicitor1">
+        <dc:Bounds x="500" y="177" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_152jcow_di" bpmnElement="Event_152jcow">
+        <dc:Bounds x="262" y="159" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="296" y="140" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/camunda/case_proceeds_in_caseman.bpmn
+++ b/src/main/resources/camunda/case_proceeds_in_caseman.bpmn
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
+  <bpmn:process id="CASE_PROCEEDS_IN_CASEMAN" isExecutable="true">
+    <bpmn:startEvent id="Event_StartClaimTakenOffline" name="Start">
+      <bpmn:outgoing>Flow_NextStartBusinessProcess</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1cb4oje" messageRef="Message_0slk3de" />
+    </bpmn:startEvent>
+    <bpmn:endEvent id="Event_EndClaimTakenOffline">
+      <bpmn:incoming>Flow_NextEndEvent</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_NextEndEvent" sourceRef="Activity_EndBusinessProcess" targetRef="Event_EndClaimTakenOffline" />
+    <bpmn:callActivity id="Activity_EndBusinessProcess" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0uljtsx</bpmn:incoming>
+      <bpmn:outgoing>Flow_NextEndEvent</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:callActivity id="Activity_StartBusinessProcess" name="Start Business Process" calledElement="StartBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_NextStartBusinessProcess</bpmn:incoming>
+      <bpmn:outgoing>Flow_NextNotifyRpa</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1nsmt51">
+      <bpmn:incoming>Flow_StartBusinessProcessAbort</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_1fn0bf1" name="Abort" attachedToRef="Activity_StartBusinessProcess">
+      <bpmn:outgoing>Flow_StartBusinessProcessAbort</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_1ilh7qa" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_StartBusinessProcessAbort" sourceRef="Event_1fn0bf1" targetRef="Event_1nsmt51" />
+    <bpmn:sequenceFlow id="Flow_NextStartBusinessProcess" sourceRef="Event_StartClaimTakenOffline" targetRef="Activity_StartBusinessProcess" />
+    <bpmn:sequenceFlow id="Flow_NextNotifyRpa" sourceRef="Activity_StartBusinessProcess" targetRef="CaseProceedsInCasemanNotifyRespondentSolicitor1" />
+    <bpmn:serviceTask id="CaseProceedsInCasemanNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_NextNotifyRpa</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hq815y</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1hq815y" sourceRef="CaseProceedsInCasemanNotifyRespondentSolicitor1" targetRef="CaseProceedsInCasemanNotifyApplicantSolicitor1" />
+    <bpmn:serviceTask id="CaseProceedsInCasemanNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hq815y</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uljtsx</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0uljtsx" sourceRef="CaseProceedsInCasemanNotifyApplicantSolicitor1" targetRef="Activity_EndBusinessProcess" />
+  </bpmn:process>
+  <bpmn:message id="Message_0slk3de" name="CASE_PROCEEDS_IN_CASEMAN" />
+  <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CASE_PROCEEDS_IN_CASEMAN">
+      <bpmndi:BPMNEdge id="Flow_14aod2o_di" bpmnElement="Flow_NextNotifyRpa">
+        <di:waypoint x="330" y="210" />
+        <di:waypoint x="370" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_NextStartBusinessProcess">
+        <di:waypoint x="188" y="210" />
+        <di:waypoint x="230" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yvpi10_di" bpmnElement="Flow_StartBusinessProcessAbort">
+        <di:waypoint x="280" y="152" />
+        <di:waypoint x="280" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hq815y_di" bpmnElement="Flow_1hq815y">
+        <di:waypoint x="470" y="210" />
+        <di:waypoint x="510" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_NextEndEvent">
+        <di:waypoint x="750" y="210" />
+        <di:waypoint x="782" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uljtsx_di" bpmnElement="Flow_0uljtsx">
+        <di:waypoint x="610" y="210" />
+        <di:waypoint x="650" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_StartClaimTakenOffline">
+        <dc:Bounds x="152" y="192" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="235" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_StartBusinessProcess">
+        <dc:Bounds x="230" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
+        <dc:Bounds x="262" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lrzkzm_di" bpmnElement="CaseProceedsInCasemanNotifyRespondentSolicitor1">
+        <dc:Bounds x="370" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
+        <dc:Bounds x="782" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
+        <dc:Bounds x="650" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1huplho_di" bpmnElement="CaseProceedsInCasemanNotifyApplicantSolicitor1">
+        <dc:Bounds x="510" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
+        <dc:Bounds x="262" y="152" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="296" y="133" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/camunda/claim_dismissed.bpmn
+++ b/src/main/resources/camunda/claim_dismissed.bpmn
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.3">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="DISMISS_CLAIM" isExecutable="true">
-    <bpmn:serviceTask id="ClaimDismissedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_CLAIM_DISMISSED</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_14aod2o</bpmn:incoming>
+      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:incoming>
       <bpmn:outgoing>Flow_0jvjzsz</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:startEvent id="Event_0t2zome" name="Start">
       <bpmn:outgoing>Flow_08myj65</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1cb4oje" messageRef="Message_0slk3de" />
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0jvjzsz" sourceRef="ClaimDismissedNotifyRespondentSolicitor1" targetRef="ClaimDismissedNotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_0jvjzsz" sourceRef="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1" targetRef="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1" />
     <bpmn:endEvent id="Event_0r8yo0r">
       <bpmn:incoming>Flow_1hce35l</bpmn:incoming>
     </bpmn:endEvent>
@@ -24,25 +24,27 @@
         <camunda:in variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1gsn98m</bpmn:incoming>
+      <bpmn:incoming>Flow_0kjctns</bpmn:incoming>
+      <bpmn:incoming>Flow_15jp8f4</bpmn:incoming>
       <bpmn:outgoing>Flow_1hce35l</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:serviceTask id="ClaimDismissedNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_CLAIM_DISMISSED</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0jvjzsz</bpmn:incoming>
       <bpmn:outgoing>Flow_1gsn98m</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
     <bpmn:callActivity id="Activity_0emdthr" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
         <camunda:in variables="all" />
         <camunda:out variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_08myj65</bpmn:incoming>
-      <bpmn:outgoing>Flow_14aod2o</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ver5zr</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:endEvent id="Event_1nsmt51">
       <bpmn:incoming>Flow_0yvpi10</bpmn:incoming>
@@ -53,64 +55,177 @@
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_0yvpi10" sourceRef="Event_1fn0bf1" targetRef="Event_1nsmt51" />
     <bpmn:sequenceFlow id="Flow_08myj65" sourceRef="Event_0t2zome" targetRef="Activity_0emdthr" />
-    <bpmn:sequenceFlow id="Flow_14aod2o" sourceRef="Activity_0emdthr" targetRef="ClaimDismissedNotifyRespondentSolicitor1" />
+    <bpmn:exclusiveGateway id="Gateway_0kj0hok">
+      <bpmn:incoming>Flow_1ver5zr</bpmn:incoming>
+      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:outgoing>
+      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:outgoing>
+      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1ver5zr" sourceRef="Activity_0emdthr" targetRef="Gateway_0kj0hok" />
+    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE" name="past claim notification deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mfdqvj</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</bpmn:incoming>
+      <bpmn:outgoing>Flow_1b1wzo6</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0mfdqvj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0kjctns</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1b1wzo6</bpmn:incoming>
+      <bpmn:outgoing>Flow_15jp8f4</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE" name="past claim dismissed deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0mfdqvj" sourceRef="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1" targetRef="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_0kjctns" sourceRef="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE" name="past claim details notification deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1b1wzo6" sourceRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1" targetRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_15jp8f4" sourceRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="DISMISS_CLAIM" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DISMISS_CLAIM">
-      <bpmndi:BPMNEdge id="Flow_1gsn98m_di" bpmnElement="Flow_1gsn98m">
-        <di:waypoint x="620" y="210" />
-        <di:waypoint x="660" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
-        <di:waypoint x="760" y="210" />
-        <di:waypoint x="802" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jvjzsz_di" bpmnElement="Flow_0jvjzsz">
-        <di:waypoint x="480" y="210" />
-        <di:waypoint x="520" y="210" />
+      <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_08myj65">
+        <di:waypoint x="188" y="260" />
+        <di:waypoint x="230" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0yvpi10_di" bpmnElement="Flow_0yvpi10">
-        <di:waypoint x="280" y="152" />
-        <di:waypoint x="280" y="118" />
+        <di:waypoint x="280" y="202" />
+        <di:waypoint x="280" y="168" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_08myj65">
-        <di:waypoint x="188" y="210" />
-        <di:waypoint x="230" y="210" />
+      <bpmndi:BPMNEdge id="Flow_1gsn98m_di" bpmnElement="Flow_1gsn98m">
+        <di:waypoint x="720" y="260" />
+        <di:waypoint x="840" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14aod2o_di" bpmnElement="Flow_14aod2o">
-        <di:waypoint x="330" y="210" />
-        <di:waypoint x="380" y="210" />
+      <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
+        <di:waypoint x="940" y="260" />
+        <di:waypoint x="982" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0bn79uc_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor1">
-        <dc:Bounds x="380" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
-        <dc:Bounds x="152" y="192" width="36" height="36" />
+      <bpmndi:BPMNEdge id="Flow_0jvjzsz_di" bpmnElement="Flow_0jvjzsz">
+        <di:waypoint x="590" y="260" />
+        <di:waypoint x="620" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ver5zr_di" bpmnElement="Flow_1ver5zr">
+        <di:waypoint x="330" y="260" />
+        <di:waypoint x="375" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nu2s7e_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE">
+        <di:waypoint x="425" y="260" />
+        <di:waypoint x="490" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="158" y="235" width="24" height="14" />
+          <dc:Bounds x="431" y="210" width="53" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nxkg6n_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE">
+        <di:waypoint x="400" y="235" />
+        <di:waypoint x="400" y="130" />
+        <di:waypoint x="490" y="130" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="405" y="80" width="50" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mfdqvj_di" bpmnElement="Flow_0mfdqvj">
+        <di:waypoint x="590" y="130" />
+        <di:waypoint x="620" y="130" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kjctns_di" bpmnElement="Flow_0kjctns">
+        <di:waypoint x="720" y="130" />
+        <di:waypoint x="780" y="130" />
+        <di:waypoint x="780" y="240" />
+        <di:waypoint x="840" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1q72q9j_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE">
+        <di:waypoint x="400" y="285" />
+        <di:waypoint x="400" y="390" />
+        <di:waypoint x="490" y="390" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="407" y="335" width="85" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1b1wzo6_di" bpmnElement="Flow_1b1wzo6">
+        <di:waypoint x="590" y="390" />
+        <di:waypoint x="620" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15jp8f4_di" bpmnElement="Flow_15jp8f4">
+        <di:waypoint x="720" y="390" />
+        <di:waypoint x="780" y="390" />
+        <di:waypoint x="780" y="280" />
+        <di:waypoint x="840" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
+        <dc:Bounds x="152" y="242" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="158" y="285" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
-        <dc:Bounds x="802" y="192" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
-        <dc:Bounds x="660" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
-        <dc:Bounds x="520" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_0emdthr">
-        <dc:Bounds x="230" y="170" width="100" height="80" />
+        <dc:Bounds x="230" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
-        <dc:Bounds x="262" y="82" width="36" height="36" />
+        <dc:Bounds x="262" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
+        <dc:Bounds x="982" y="242" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
+        <dc:Bounds x="840" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
+        <dc:Bounds x="375" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0bn79uc_di" bpmnElement="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1">
+        <dc:Bounds x="490" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1">
+        <dc:Bounds x="620" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1">
+        <dc:Bounds x="490" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1woptoy_di" bpmnElement="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1">
+        <dc:Bounds x="490" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0b0k9wh_di" bpmnElement="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1">
+        <dc:Bounds x="620" y="90" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09c5wbn_di" bpmnElement="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1">
+        <dc:Bounds x="620" y="350" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
-        <dc:Bounds x="262" y="152" width="36" height="36" />
+        <dc:Bounds x="262" y="202" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="296" y="133" width="27" height="14" />
+          <dc:Bounds x="296" y="183" width="27" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>

--- a/src/main/resources/camunda/claim_dismissed.bpmn
+++ b/src/main/resources/camunda/claim_dismissed.bpmn
@@ -1,20 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="DISMISS_CLAIM" isExecutable="true">
-    <bpmn:serviceTask id="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:incoming>
-      <bpmn:outgoing>Flow_0jvjzsz</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:startEvent id="Event_0t2zome" name="Start">
       <bpmn:outgoing>Flow_08myj65</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1cb4oje" messageRef="Message_0slk3de" />
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0jvjzsz" sourceRef="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1" targetRef="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1" />
     <bpmn:endEvent id="Event_0r8yo0r">
       <bpmn:incoming>Flow_1hce35l</bpmn:incoming>
     </bpmn:endEvent>
@@ -24,20 +14,19 @@
         <camunda:in variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1gsn98m</bpmn:incoming>
-      <bpmn:incoming>Flow_0kjctns</bpmn:incoming>
-      <bpmn:incoming>Flow_15jp8f4</bpmn:incoming>
       <bpmn:outgoing>Flow_1hce35l</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:serviceTask id="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimDismissedNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0jvjzsz</bpmn:incoming>
+      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:incoming>
+      <bpmn:incoming>Flow_1dra5bz</bpmn:incoming>
       <bpmn:outgoing>Flow_1gsn98m</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1gsn98m" sourceRef="ClaimDismissedNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
     <bpmn:callActivity id="Activity_0emdthr" name="Start Business Process" calledElement="StartBusinessProcess">
       <bpmn:extensionElements>
         <camunda:in variables="all" />
@@ -55,67 +44,52 @@
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_0yvpi10" sourceRef="Event_1fn0bf1" targetRef="Event_1nsmt51" />
     <bpmn:sequenceFlow id="Flow_08myj65" sourceRef="Event_0t2zome" targetRef="Activity_0emdthr" />
-    <bpmn:exclusiveGateway id="Gateway_0kj0hok">
-      <bpmn:incoming>Flow_1ver5zr</bpmn:incoming>
-      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:outgoing>
-      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:outgoing>
-      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1ver5zr" sourceRef="Activity_0emdthr" targetRef="Gateway_0kj0hok" />
-    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE" name="past claim notification deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimDismissedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</camunda:inputParameter>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:incoming>
-      <bpmn:outgoing>Flow_0mfdqvj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dra5bz</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</bpmn:incoming>
-      <bpmn:outgoing>Flow_1b1wzo6</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0mfdqvj</bpmn:incoming>
-      <bpmn:outgoing>Flow_0kjctns</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1b1wzo6</bpmn:incoming>
-      <bpmn:outgoing>Flow_15jp8f4</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE" name="past claim dismissed deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1">
+    <bpmn:exclusiveGateway id="Gateway_0kj0hok">
+      <bpmn:incoming>Flow_1ver5zr</bpmn:incoming>
+      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE</bpmn:outgoing>
+      <bpmn:outgoing>Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE" name="past claim dismissed deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedNotifyRespondentSolicitor1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0mfdqvj" sourceRef="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1" targetRef="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1" />
-    <bpmn:sequenceFlow id="Flow_0kjctns" sourceRef="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
-    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE" name="past claim details notification deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE"}</bpmn:conditionExpression>
+    <bpmn:sequenceFlow id="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE" name="past claim (or claim details) notification deadline" sourceRef="Gateway_0kj0hok" targetRef="ClaimDismissedNotifyApplicantSolicitor1">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE" || flowState == "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1b1wzo6" sourceRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1" targetRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1" />
-    <bpmn:sequenceFlow id="Flow_15jp8f4" sourceRef="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1ver5zr" sourceRef="Activity_0emdthr" targetRef="Gateway_0kj0hok" />
+    <bpmn:sequenceFlow id="Flow_1dra5bz" sourceRef="ClaimDismissedNotifyRespondentSolicitor1" targetRef="ClaimDismissedNotifyApplicantSolicitor1" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="DISMISS_CLAIM" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DISMISS_CLAIM">
+      <bpmndi:BPMNEdge id="Flow_1nxkg6n_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE">
+        <di:waypoint x="400" y="235" />
+        <di:waypoint x="400" y="130" />
+        <di:waypoint x="460" y="130" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="395" y="80" width="50" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1nu2s7e_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE">
+        <di:waypoint x="425" y="260" />
+        <di:waypoint x="580" y="260" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="476" y="265" width="67" height="53" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ver5zr_di" bpmnElement="Flow_1ver5zr">
+        <di:waypoint x="330" y="260" />
+        <di:waypoint x="375" y="260" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_08myj65">
         <di:waypoint x="188" y="260" />
         <di:waypoint x="230" y="260" />
@@ -125,63 +99,17 @@
         <di:waypoint x="280" y="168" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gsn98m_di" bpmnElement="Flow_1gsn98m">
-        <di:waypoint x="720" y="260" />
-        <di:waypoint x="840" y="260" />
+        <di:waypoint x="680" y="260" />
+        <di:waypoint x="730" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
-        <di:waypoint x="940" y="260" />
-        <di:waypoint x="982" y="260" />
+        <di:waypoint x="830" y="260" />
+        <di:waypoint x="882" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0jvjzsz_di" bpmnElement="Flow_0jvjzsz">
-        <di:waypoint x="590" y="260" />
-        <di:waypoint x="620" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ver5zr_di" bpmnElement="Flow_1ver5zr">
-        <di:waypoint x="330" y="260" />
-        <di:waypoint x="375" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1nu2s7e_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE">
-        <di:waypoint x="425" y="260" />
-        <di:waypoint x="490" y="260" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="431" y="210" width="53" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1nxkg6n_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE">
-        <di:waypoint x="400" y="235" />
-        <di:waypoint x="400" y="130" />
-        <di:waypoint x="490" y="130" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="405" y="80" width="50" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mfdqvj_di" bpmnElement="Flow_0mfdqvj">
-        <di:waypoint x="590" y="130" />
-        <di:waypoint x="620" y="130" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0kjctns_di" bpmnElement="Flow_0kjctns">
-        <di:waypoint x="720" y="130" />
-        <di:waypoint x="780" y="130" />
-        <di:waypoint x="780" y="240" />
-        <di:waypoint x="840" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1q72q9j_di" bpmnElement="Flow_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE">
-        <di:waypoint x="400" y="285" />
-        <di:waypoint x="400" y="390" />
-        <di:waypoint x="490" y="390" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="407" y="335" width="85" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1b1wzo6_di" bpmnElement="Flow_1b1wzo6">
-        <di:waypoint x="590" y="390" />
-        <di:waypoint x="620" y="390" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_15jp8f4_di" bpmnElement="Flow_15jp8f4">
-        <di:waypoint x="720" y="390" />
-        <di:waypoint x="780" y="390" />
-        <di:waypoint x="780" y="280" />
-        <di:waypoint x="840" y="280" />
+      <bpmndi:BPMNEdge id="Flow_1dra5bz_di" bpmnElement="Flow_1dra5bz">
+        <di:waypoint x="560" y="130" />
+        <di:waypoint x="630" y="130" />
+        <di:waypoint x="630" y="220" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
         <dc:Bounds x="152" y="242" width="36" height="36" />
@@ -195,32 +123,20 @@
       <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
         <dc:Bounds x="262" y="132" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
-        <dc:Bounds x="982" y="242" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
-        <dc:Bounds x="840" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0kj0hok_di" bpmnElement="Gateway_0kj0hok" isMarkerVisible="true">
         <dc:Bounds x="375" y="235" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0bn79uc_di" bpmnElement="ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1">
-        <dc:Bounds x="490" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedNotifyRespondentSolicitor1">
+        <dc:Bounds x="460" y="90" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1">
-        <dc:Bounds x="620" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_03lhz3m_di" bpmnElement="ClaimDismissedNotifyApplicantSolicitor1">
+        <dc:Bounds x="580" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1n01tzr_di" bpmnElement="ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1">
-        <dc:Bounds x="490" y="90" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
+        <dc:Bounds x="730" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1woptoy_di" bpmnElement="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1">
-        <dc:Bounds x="490" y="350" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0b0k9wh_di" bpmnElement="ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1">
-        <dc:Bounds x="620" y="90" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_09c5wbn_di" bpmnElement="ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1">
-        <dc:Bounds x="620" y="350" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
+        <dc:Bounds x="882" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
         <dc:Bounds x="262" y="202" width="36" height="36" />

--- a/src/main/resources/camunda/claimant_response.bpmn
+++ b/src/main/resources/camunda/claimant_response.bpmn
@@ -1,30 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="CLAIMANT_RESPONSE_PROCESS_ID" isExecutable="true">
-    <bpmn:sequenceFlow id="Flow_1xdr8bm" sourceRef="ClaimantResponseNotifyRespondentSolicitor1" targetRef="ClaimantResponseNotifyApplicantSolicitor1" />
-    <bpmn:serviceTask id="ClaimantResponseNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_TRANSFERRED_TO_LOCAL_COURT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0d6xhkf</bpmn:incoming>
-      <bpmn:outgoing>Flow_1xdr8bm</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:serviceTask id="ClaimantResponseNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
-      <bpmn:extensionElements>
-        <camunda:inputOutput>
-          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_TRANSFERRED_TO_LOCAL_COURT</camunda:inputParameter>
-        </camunda:inputOutput>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1xdr8bm</bpmn:incoming>
-      <bpmn:outgoing>Flow_0veyd24</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0g2t112</bpmn:outgoing>
       <bpmn:messageEventDefinition id="MessageEventDefinition_1oxj7lg" messageRef="Message_0ttrrz3" />
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0veyd24" sourceRef="ClaimantResponseNotifyApplicantSolicitor1" targetRef="Gateway_PROCEED_OR_NOT_PROCEED" />
     <bpmn:endEvent id="Event_07ek9xj">
       <bpmn:incoming>Flow_0tgwl48</bpmn:incoming>
     </bpmn:endEvent>
@@ -76,7 +56,7 @@
     <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" />
     <bpmn:sequenceFlow id="Flow_17evp7q" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_1cweuly" />
     <bpmn:exclusiveGateway id="Gateway_PROCEED_OR_NOT_PROCEED">
-      <bpmn:incoming>Flow_0veyd24</bpmn:incoming>
+      <bpmn:incoming>Flow_0d6xhkf</bpmn:incoming>
       <bpmn:outgoing>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:outgoing>
       <bpmn:outgoing>Flow_FULL_DEFENCE_PROCEED</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -86,7 +66,7 @@
     <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_PROCEED" name="Applicant confirms to proceed" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseGenerateDirectionsQuestionnaire">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_DEFENCE_PROCEED"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0d6xhkf" sourceRef="ProceedOfflineForResponseToDefence" targetRef="ClaimantResponseNotifyRespondentSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_0d6xhkf" sourceRef="ProceedOfflineForResponseToDefence" targetRef="Gateway_PROCEED_OR_NOT_PROCEED" />
     <bpmn:serviceTask id="ProceedOfflineForResponseToDefence" name="Proceed offline (Response to defence)" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -141,36 +121,53 @@
   <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CLAIMANT_RESPONSE_PROCESS_ID">
-      <bpmndi:BPMNEdge id="Flow_0d6xhkf_di" bpmnElement="Flow_0d6xhkf">
-        <di:waypoint x="470" y="260" />
-        <di:waypoint x="530" y="260" />
+      <bpmndi:BPMNEdge id="Flow_0fqn57l_di" bpmnElement="Flow_0fqn57l">
+        <di:waypoint x="970" y="260" />
+        <di:waypoint x="1010" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fz18qx_di" bpmnElement="Flow_FULL_DEFENCE_PROCEED">
-        <di:waypoint x="840" y="235" />
+      <bpmndi:BPMNEdge id="Flow_02s7jvc_di" bpmnElement="Flow_02s7jvc">
+        <di:waypoint x="970" y="80" />
+        <di:waypoint x="1060" y="80" />
+        <di:waypoint x="1060" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hdxw94_di" bpmnElement="Flow_1hdxw94">
+        <di:waypoint x="840" y="260" />
+        <di:waypoint x="870" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1omrvfy_di" bpmnElement="Flow_1omrvfy">
         <di:waypoint x="840" y="80" />
         <di:waypoint x="870" y="80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0d6xhkf_di" bpmnElement="Flow_0d6xhkf">
+        <di:waypoint x="490" y="260" />
+        <di:waypoint x="555" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fz18qx_di" bpmnElement="Flow_FULL_DEFENCE_PROCEED">
+        <di:waypoint x="580" y="235" />
+        <di:waypoint x="580" y="80" />
+        <di:waypoint x="610" y="80" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="745" y="155" width="90" height="27" />
+          <dc:Bounds x="485" y="155" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_185dsos_di" bpmnElement="Flow_FULL_DEFENCE_NOT_PROCEED">
-        <di:waypoint x="865" y="260" />
-        <di:waypoint x="1000" y="260" />
+        <di:waypoint x="605" y="260" />
+        <di:waypoint x="740" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="870" y="276" width="90" height="27" />
+          <dc:Bounds x="610" y="276" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17evp7q_di" bpmnElement="Flow_17evp7q">
-        <di:waypoint x="1370" y="260" />
-        <di:waypoint x="1410" y="260" />
+        <di:waypoint x="1110" y="260" />
+        <di:waypoint x="1150" y="260" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hr7okm_di" bpmnElement="Flow_1hr7okm">
-        <di:waypoint x="970" y="80" />
-        <di:waypoint x="1000" y="80" />
+        <di:waypoint x="710" y="80" />
+        <di:waypoint x="740" y="80" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19mft34_di" bpmnElement="Flow_19mft34">
         <di:waypoint x="330" y="257" />
-        <di:waypoint x="370" y="257" />
+        <di:waypoint x="390" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0g2t112_di" bpmnElement="Flow_0g2t112">
         <di:waypoint x="188" y="260" />
@@ -181,78 +178,47 @@
         <di:waypoint x="280" y="165" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0tgwl48_di" bpmnElement="Flow_0tgwl48">
-        <di:waypoint x="1510" y="260" />
-        <di:waypoint x="1552" y="260" />
+        <di:waypoint x="1250" y="260" />
+        <di:waypoint x="1292" y="260" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0veyd24_di" bpmnElement="Flow_0veyd24">
-        <di:waypoint x="770" y="260" />
-        <di:waypoint x="815" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xdr8bm_di" bpmnElement="Flow_1xdr8bm">
-        <di:waypoint x="630" y="260" />
-        <di:waypoint x="670" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1omrvfy_di" bpmnElement="Flow_1omrvfy">
-        <di:waypoint x="1100" y="80" />
-        <di:waypoint x="1130" y="80" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hdxw94_di" bpmnElement="Flow_1hdxw94">
-        <di:waypoint x="1100" y="260" />
-        <di:waypoint x="1130" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02s7jvc_di" bpmnElement="Flow_02s7jvc">
-        <di:waypoint x="1230" y="80" />
-        <di:waypoint x="1320" y="80" />
-        <di:waypoint x="1320" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fqn57l_di" bpmnElement="Flow_0fqn57l">
-        <di:waypoint x="1230" y="260" />
-        <di:waypoint x="1270" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="242" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
+        <dc:Bounds x="1292" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
-        <dc:Bounds x="230" y="217" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
+        <dc:Bounds x="1150" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05zzi0k_di" bpmnElement="ClaimantResponseGenerateDirectionsQuestionnaire">
+        <dc:Bounds x="610" y="40" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
+        <dc:Bounds x="1010" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0p15z9i_di" bpmnElement="Gateway_PROCEED_OR_NOT_PROCEED" isMarkerVisible="true">
+        <dc:Bounds x="555" y="235" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1c4psp2_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
+        <dc:Bounds x="740" y="40" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
+        <dc:Bounds x="740" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13ulnqp_di" bpmnElement="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC">
+        <dc:Bounds x="870" y="40" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0f90qs7_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
+        <dc:Bounds x="870" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
         <dc:Bounds x="262" y="129" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_028lxzs_di" bpmnElement="ProceedOfflineForResponseToDefence">
-        <dc:Bounds x="370" y="217" width="100" height="80" />
+        <dc:Bounds x="390" y="217" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="ClaimantResponseNotifyRespondentSolicitor1">
-        <dc:Bounds x="530" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
+        <dc:Bounds x="230" y="217" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13h7jgg_di" bpmnElement="ClaimantResponseNotifyApplicantSolicitor1">
-        <dc:Bounds x="670" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0p15z9i_di" bpmnElement="Gateway_PROCEED_OR_NOT_PROCEED" isMarkerVisible="true">
-        <dc:Bounds x="815" y="235" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_05zzi0k_di" bpmnElement="ClaimantResponseGenerateDirectionsQuestionnaire">
-        <dc:Bounds x="870" y="40" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1c4psp2_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="1000" y="40" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1up0lu9_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="1000" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13ulnqp_di" bpmnElement="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC">
-        <dc:Bounds x="1130" y="40" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0f90qs7_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
-        <dc:Bounds x="1130" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
-        <dc:Bounds x="1552" y="242" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="1270" y="220" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
-        <dc:Bounds x="1410" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
         <dc:Bounds x="262" y="199" width="36" height="36" />

--- a/src/main/resources/camunda/claimant_response.bpmn
+++ b/src/main/resources/camunda/claimant_response.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_18h9iji" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="CLAIMANT_RESPONSE_PROCESS_ID" isExecutable="true">
     <bpmn:sequenceFlow id="Flow_1xdr8bm" sourceRef="ClaimantResponseNotifyRespondentSolicitor1" targetRef="ClaimantResponseNotifyApplicantSolicitor1" />
     <bpmn:serviceTask id="ClaimantResponseNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
@@ -69,23 +69,43 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1hr7okm</bpmn:incoming>
-      <bpmn:incoming>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:incoming>
+      <bpmn:incoming>Flow_1fxy5qy</bpmn:incoming>
+      <bpmn:incoming>Flow_0v0npem</bpmn:incoming>
       <bpmn:outgoing>Flow_17evp7q</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1" />
     <bpmn:sequenceFlow id="Flow_17evp7q" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_1cweuly" />
     <bpmn:exclusiveGateway id="Gateway_PROCEED_OR_NOT_PROCEED">
       <bpmn:incoming>Flow_0veyd24</bpmn:incoming>
       <bpmn:outgoing>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:outgoing>
       <bpmn:outgoing>Flow_FULL_DEFENCE_PROCEED</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_NOT_PROCEED" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="NotifyRoboticsOnCaseHandedOffline">
+    <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_NOT_PROCEED" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_DEFENCE_NOT_PROCEED"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_PROCEED" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseGenerateDirectionsQuestionnaire">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_DEFENCE_PROCEED"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hr7okm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fxy5qy</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1fxy5qy" sourceRef="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:serviceTask id="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:incoming>
+      <bpmn:outgoing>Flow_0v0npem</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0v0npem" sourceRef="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:textAnnotation id="TextAnnotation_1cdav8i">
       <bpmn:text>Applicant confirms to proceed</bpmn:text>
     </bpmn:textAnnotation>
@@ -101,16 +121,15 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_185dsos_di" bpmnElement="Flow_FULL_DEFENCE_NOT_PROCEED">
         <di:waypoint x="705" y="257" />
-        <di:waypoint x="910" y="257" />
+        <di:waypoint x="860" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17evp7q_di" bpmnElement="Flow_17evp7q">
-        <di:waypoint x="1010" y="257" />
-        <di:waypoint x="1070" y="257" />
+        <di:waypoint x="1120" y="257" />
+        <di:waypoint x="1170" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hr7okm_di" bpmnElement="Flow_1hr7okm">
         <di:waypoint x="820" y="120" />
-        <di:waypoint x="960" y="120" />
-        <di:waypoint x="960" y="217" />
+        <di:waypoint x="860" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19mft34_di" bpmnElement="Flow_19mft34">
         <di:waypoint x="330" y="257" />
@@ -125,8 +144,8 @@
         <di:waypoint x="280" y="165" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0tgwl48_di" bpmnElement="Flow_0tgwl48">
-        <di:waypoint x="1170" y="257" />
-        <di:waypoint x="1222" y="257" />
+        <di:waypoint x="1270" y="257" />
+        <di:waypoint x="1322" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0veyd24_di" bpmnElement="Flow_0veyd24">
         <di:waypoint x="630" y="257" />
@@ -135,6 +154,15 @@
       <bpmndi:BPMNEdge id="Flow_1xdr8bm_di" bpmnElement="Flow_1xdr8bm">
         <di:waypoint x="480" y="257" />
         <di:waypoint x="530" y="257" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fxy5qy_di" bpmnElement="Flow_1fxy5qy">
+        <di:waypoint x="960" y="120" />
+        <di:waypoint x="1070" y="120" />
+        <di:waypoint x="1070" y="217" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v0npem_di" bpmnElement="Flow_0v0npem">
+        <di:waypoint x="960" y="257" />
+        <di:waypoint x="1020" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="ClaimantResponseNotifyRespondentSolicitor1">
         <dc:Bounds x="380" y="217" width="100" height="80" />
@@ -145,12 +173,6 @@
       <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="242" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
-        <dc:Bounds x="1222" y="239" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
-        <dc:Bounds x="1070" y="217" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05zzi0k_di" bpmnElement="ClaimantResponseGenerateDirectionsQuestionnaire">
         <dc:Bounds x="720" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -160,14 +182,26 @@
       <bpmndi:BPMNShape id="Event_0nc34kd_di" bpmnElement="Event_0nc34kd">
         <dc:Bounds x="262" y="129" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="910" y="217" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0p15z9i_di" bpmnElement="Gateway_PROCEED_OR_NOT_PROCEED" isMarkerVisible="true">
         <dc:Bounds x="655" y="232" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_1cdav8i_di" bpmnElement="TextAnnotation_1cdav8i">
         <dc:Bounds x="610" y="80" width="100" height="53" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
+        <dc:Bounds x="1322" y="239" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
+        <dc:Bounds x="1170" y="217" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1typ2td_di" bpmnElement="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1">
+        <dc:Bounds x="860" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n07bsp_di" bpmnElement="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1">
+        <dc:Bounds x="860" y="217" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
+        <dc:Bounds x="1020" y="217" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
         <dc:Bounds x="262" y="199" width="36" height="36" />

--- a/src/main/resources/camunda/claimant_response.bpmn
+++ b/src/main/resources/camunda/claimant_response.bpmn
@@ -69,8 +69,8 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1fxy5qy</bpmn:incoming>
-      <bpmn:incoming>Flow_0v0npem</bpmn:incoming>
+      <bpmn:incoming>Flow_0x5tsn1</bpmn:incoming>
+      <bpmn:incoming>Flow_0og10md</bpmn:incoming>
       <bpmn:outgoing>Flow_17evp7q</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" />
@@ -95,7 +95,7 @@
       <bpmn:incoming>Flow_1hr7okm</bpmn:incoming>
       <bpmn:outgoing>Flow_1fxy5qy</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1fxy5qy" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_1fxy5qy" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" targetRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" />
     <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -105,7 +105,27 @@
       <bpmn:incoming>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:incoming>
       <bpmn:outgoing>Flow_0v0npem</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0v0npem" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_0v0npem" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" />
+    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0v0npem</bpmn:incoming>
+      <bpmn:outgoing>Flow_0x5tsn1</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0x5tsn1" sourceRef="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1fxy5qy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0og10md</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0og10md" sourceRef="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:textAnnotation id="TextAnnotation_1cdav8i">
       <bpmn:text>Applicant confirms to proceed</bpmn:text>
     </bpmn:textAnnotation>
@@ -114,22 +134,30 @@
   <bpmn:error id="Error_1alq6sw" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CLAIMANT_RESPONSE_PROCESS_ID">
+      <bpmndi:BPMNEdge id="Flow_0v0npem_di" bpmnElement="Flow_0v0npem">
+        <di:waypoint x="940" y="257" />
+        <di:waypoint x="970" y="257" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1fxy5qy_di" bpmnElement="Flow_1fxy5qy">
+        <di:waypoint x="940" y="120" />
+        <di:waypoint x="970" y="120" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0fz18qx_di" bpmnElement="Flow_FULL_DEFENCE_PROCEED">
         <di:waypoint x="680" y="232" />
         <di:waypoint x="680" y="120" />
-        <di:waypoint x="720" y="120" />
+        <di:waypoint x="710" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_185dsos_di" bpmnElement="Flow_FULL_DEFENCE_NOT_PROCEED">
         <di:waypoint x="705" y="257" />
-        <di:waypoint x="860" y="257" />
+        <di:waypoint x="840" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17evp7q_di" bpmnElement="Flow_17evp7q">
-        <di:waypoint x="1120" y="257" />
-        <di:waypoint x="1170" y="257" />
+        <di:waypoint x="1210" y="257" />
+        <di:waypoint x="1240" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hr7okm_di" bpmnElement="Flow_1hr7okm">
-        <di:waypoint x="820" y="120" />
-        <di:waypoint x="860" y="120" />
+        <di:waypoint x="810" y="120" />
+        <di:waypoint x="840" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19mft34_di" bpmnElement="Flow_19mft34">
         <di:waypoint x="330" y="257" />
@@ -144,8 +172,8 @@
         <di:waypoint x="280" y="165" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0tgwl48_di" bpmnElement="Flow_0tgwl48">
-        <di:waypoint x="1270" y="257" />
-        <di:waypoint x="1322" y="257" />
+        <di:waypoint x="1340" y="257" />
+        <di:waypoint x="1372" y="257" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0veyd24_di" bpmnElement="Flow_0veyd24">
         <di:waypoint x="630" y="257" />
@@ -155,14 +183,14 @@
         <di:waypoint x="480" y="257" />
         <di:waypoint x="530" y="257" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1fxy5qy_di" bpmnElement="Flow_1fxy5qy">
-        <di:waypoint x="960" y="120" />
-        <di:waypoint x="1070" y="120" />
-        <di:waypoint x="1070" y="217" />
+      <bpmndi:BPMNEdge id="Flow_0x5tsn1_di" bpmnElement="Flow_0x5tsn1">
+        <di:waypoint x="1070" y="257" />
+        <di:waypoint x="1110" y="257" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v0npem_di" bpmnElement="Flow_0v0npem">
-        <di:waypoint x="960" y="257" />
-        <di:waypoint x="1020" y="257" />
+      <bpmndi:BPMNEdge id="Flow_0og10md_di" bpmnElement="Flow_0og10md">
+        <di:waypoint x="1070" y="120" />
+        <di:waypoint x="1160" y="120" />
+        <di:waypoint x="1160" y="217" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="ClaimantResponseNotifyRespondentSolicitor1">
         <dc:Bounds x="380" y="217" width="100" height="80" />
@@ -172,9 +200,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1diii28_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="242" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_05zzi0k_di" bpmnElement="ClaimantResponseGenerateDirectionsQuestionnaire">
-        <dc:Bounds x="720" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0gt1863_di" bpmnElement="Activity_0gt1863">
         <dc:Bounds x="230" y="217" width="100" height="80" />
@@ -189,19 +214,28 @@
         <dc:Bounds x="610" y="80" width="100" height="53" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_07ek9xj_di" bpmnElement="Event_07ek9xj">
-        <dc:Bounds x="1322" y="239" width="36" height="36" />
+        <dc:Bounds x="1372" y="239" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
-        <dc:Bounds x="1170" y="217" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1typ2td_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="860" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0n07bsp_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
-        <dc:Bounds x="860" y="217" width="100" height="80" />
+        <dc:Bounds x="1240" y="217" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="1020" y="217" width="100" height="80" />
+        <dc:Bounds x="1110" y="217" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1typ2td_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
+        <dc:Bounds x="840" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n07bsp_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
+        <dc:Bounds x="840" y="217" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_05zzi0k_di" bpmnElement="ClaimantResponseGenerateDirectionsQuestionnaire">
+        <dc:Bounds x="710" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1dmi256_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC">
+        <dc:Bounds x="970" y="217" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_14yccag_di" bpmnElement="ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC">
+        <dc:Bounds x="970" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1p3emre_di" bpmnElement="Event_1p3emre">
         <dc:Bounds x="262" y="199" width="36" height="36" />

--- a/src/main/resources/camunda/claimant_response.bpmn
+++ b/src/main/resources/camunda/claimant_response.bpmn
@@ -73,20 +73,20 @@
       <bpmn:incoming>Flow_0v0npem</bpmn:incoming>
       <bpmn:outgoing>Flow_17evp7q</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_1hr7okm" sourceRef="ClaimantResponseGenerateDirectionsQuestionnaire" targetRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" />
     <bpmn:sequenceFlow id="Flow_17evp7q" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_1cweuly" />
     <bpmn:exclusiveGateway id="Gateway_PROCEED_OR_NOT_PROCEED">
       <bpmn:incoming>Flow_0veyd24</bpmn:incoming>
       <bpmn:outgoing>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:outgoing>
       <bpmn:outgoing>Flow_FULL_DEFENCE_PROCEED</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_NOT_PROCEED" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1">
+    <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_NOT_PROCEED" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_DEFENCE_NOT_PROCEED"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_FULL_DEFENCE_PROCEED" sourceRef="Gateway_PROCEED_OR_NOT_PROCEED" targetRef="ClaimantResponseGenerateDirectionsQuestionnaire">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.FULL_DEFENCE_PROCEED"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:serviceTask id="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED</camunda:inputParameter>
@@ -95,8 +95,8 @@
       <bpmn:incoming>Flow_1hr7okm</bpmn:incoming>
       <bpmn:outgoing>Flow_1fxy5qy</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1fxy5qy" sourceRef="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
-    <bpmn:serviceTask id="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:sequenceFlow id="Flow_1fxy5qy" sourceRef="ClaimantConfirmsToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:serviceTask id="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED</camunda:inputParameter>
@@ -105,7 +105,7 @@
       <bpmn:incoming>Flow_FULL_DEFENCE_NOT_PROCEED</bpmn:incoming>
       <bpmn:outgoing>Flow_0v0npem</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0v0npem" sourceRef="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_0v0npem" sourceRef="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:textAnnotation id="TextAnnotation_1cdav8i">
       <bpmn:text>Applicant confirms to proceed</bpmn:text>
     </bpmn:textAnnotation>
@@ -194,10 +194,10 @@
       <bpmndi:BPMNShape id="Activity_14sbez9_di" bpmnElement="Activity_1cweuly">
         <dc:Bounds x="1170" y="217" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1typ2td_di" bpmnElement="ClaimantResponseConfirmsToProceedNotifyRespondentSolicitor1">
+      <bpmndi:BPMNShape id="Activity_1typ2td_di" bpmnElement="ClaimantConfirmsToProceedNotifyRespondentSolicitor1">
         <dc:Bounds x="860" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0n07bsp_di" bpmnElement="ClaimantResponseConfirmsNotToProceedNotifyRespondentSolicitor1">
+      <bpmndi:BPMNShape id="Activity_0n07bsp_di" bpmnElement="ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1">
         <dc:Bounds x="860" y="217" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_15wxp1o_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">

--- a/src/main/resources/camunda/create_claim.bpmn
+++ b/src/main/resources/camunda/create_claim.bpmn
@@ -42,9 +42,6 @@
     <bpmn:sequenceFlow id="Flow_0eps4bo" sourceRef="CreateClaimMakePayment" targetRef="Gateway_0ea6cjs" />
     <bpmn:sequenceFlow id="Flow_0oy1b4w" sourceRef="Activity_032r20h" targetRef="CaseAssignmentToApplicantSolicitor1" />
     <bpmn:sequenceFlow id="Flow_1av9hkz" sourceRef="CreateClaimPaymentFailedNotifyApplicantSolicitor1" targetRef="Activity_19rrcw0" />
-    <bpmn:sequenceFlow id="Flow_1mjmvjy" name="Respondent 1 represented and registered" sourceRef="Gateway_1i24lv2" targetRef="Activity_19rrcw0">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.AWAITING_CASE_NOTIFICATION"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1mak1f7" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_19rrcw0" />
     <bpmn:sequenceFlow id="Flow_08x3izf" sourceRef="Activity_19rrcw0" targetRef="Event_1irqmkk" />
     <bpmn:sequenceFlow id="Flow_0znizfx" sourceRef="Event_0yfoky6" targetRef="Activity_032r20h" />
@@ -56,8 +53,8 @@
         <camunda:in variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1mak1f7</bpmn:incoming>
-      <bpmn:incoming>Flow_1mjmvjy</bpmn:incoming>
       <bpmn:incoming>Flow_1av9hkz</bpmn:incoming>
+      <bpmn:incoming>Flow_1afa879</bpmn:incoming>
       <bpmn:outgoing>Flow_08x3izf</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:serviceTask id="CreateClaimMakePayment" name="Make PBA Payment" camunda:type="external" camunda:topic="processPayment">
@@ -94,8 +91,8 @@
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="Gateway_1i24lv2">
       <bpmn:incoming>Flow_1fr3g5j</bpmn:incoming>
-      <bpmn:outgoing>Flow_1mjmvjy</bpmn:outgoing>
       <bpmn:outgoing>Flow_1uhc41o</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0e25dh3</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:serviceTask id="CreateClaimProceedsOfflineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -125,6 +122,17 @@
       <bpmn:outgoing>Flow_1yheet4</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1yheet4" sourceRef="CaseAssignmentToApplicantSolicitor1" targetRef="CreateClaimMakePayment" />
+    <bpmn:serviceTask id="CreateClaimContinuingOnlineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_CONTINUING_ONLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0e25dh3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1afa879</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0e25dh3" sourceRef="Gateway_1i24lv2" targetRef="CreateClaimContinuingOnlineNotifyApplicantSolicitor1" />
+    <bpmn:sequenceFlow id="Flow_1afa879" sourceRef="CreateClaimContinuingOnlineNotifyApplicantSolicitor1" targetRef="Activity_19rrcw0" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="CreateClaim">
@@ -147,14 +155,6 @@
         <di:waypoint x="1250" y="140" />
         <di:waypoint x="1300" y="140" />
         <di:waypoint x="1300" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mjmvjy_di" bpmnElement="Flow_1mjmvjy">
-        <di:waypoint x="940" y="215" />
-        <di:waypoint x="940" y="240" />
-        <di:waypoint x="1250" y="240" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="921" y="266" width="81" height="40" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1av9hkz_di" bpmnElement="Flow_1av9hkz">
         <di:waypoint x="1250" y="350" />
@@ -205,6 +205,15 @@
         <di:waypoint x="340" y="202" />
         <di:waypoint x="340" y="168" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0e25dh3_di" bpmnElement="Flow_0e25dh3">
+        <di:waypoint x="940" y="215" />
+        <di:waypoint x="940" y="240" />
+        <di:waypoint x="1010" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1afa879_di" bpmnElement="Flow_1afa879">
+        <di:waypoint x="1110" y="240" />
+        <di:waypoint x="1250" y="240" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0yfoky6_di" bpmnElement="Event_0yfoky6">
         <dc:Bounds x="212" y="242" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -246,6 +255,9 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zxgw4d_di" bpmnElement="CaseAssignmentToApplicantSolicitor1">
         <dc:Bounds x="440" y="220" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1joh3sr_di" bpmnElement="CreateClaimContinuingOnlineNotifyApplicantSolicitor1">
+        <dc:Bounds x="1010" y="200" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0x002k6_di" bpmnElement="Event_0x002k6">
         <dc:Bounds x="322" y="202" width="36" height="36" />

--- a/src/main/resources/camunda/defendant_response.bpmn
+++ b/src/main/resources/camunda/defendant_response.bpmn
@@ -49,7 +49,7 @@
     <bpmn:sequenceFlow id="Flow_01e5t4p" sourceRef="Gateway_1q9qem9" targetRef="DefendantResponseCaseHandedOfflineNotifyRespondentSolicitor1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${flowState == "MAIN.RESPONDENT_FULL_ADMISSION" || flowState == "MAIN.RESPONDENT_PART_ADMISSION" || flowState == "MAIN.RESPONDENT_COUNTER_CLAIM"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0qgvakl" sourceRef="DefendantResponseCaseHandedOfflineNotifyApplicantSolicitor1" targetRef="NotifyRoboticsOnCaseHandedOffline" />
+    <bpmn:sequenceFlow id="Flow_0qgvakl" sourceRef="DefendantResponseCaseHandedOfflineNotifyApplicantSolicitor1" targetRef="DefendantResponseCaseHandedOfflineNotifyRespondentSolicitor1CC" />
     <bpmn:endEvent id="Event_15p049m">
       <bpmn:incoming>Flow_0jauxrx</bpmn:incoming>
     </bpmn:endEvent>
@@ -62,7 +62,7 @@
       <bpmn:incoming>Flow_1a2n9ax</bpmn:incoming>
       <bpmn:outgoing>Flow_0jauxrx</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="Flow_1tgi30k" sourceRef="DefendantResponseFullDefenceNotifyApplicantSolicitor1" targetRef="DefendantResponseFullDefenceGenerateDirectionsQuestionnaire" />
+    <bpmn:sequenceFlow id="Flow_1tgi30k" sourceRef="DefendantResponseFullDefenceNotifyApplicantSolicitor1" targetRef="DefendantResponseFullDefenceNotifyRespondentSolicitor1CC" />
     <bpmn:sequenceFlow id="Flow_1bv320r" sourceRef="DefendantResponseFullDefenceGenerateDirectionsQuestionnaire" targetRef="Activity_1m5szz9" />
     <bpmn:serviceTask id="DefendantResponseFullDefenceGenerateDirectionsQuestionnaire" name="Generate DQ" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
@@ -70,7 +70,7 @@
           <camunda:inputParameter name="caseEvent">GENERATE_DIRECTIONS_QUESTIONNAIRE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1tgi30k</bpmn:incoming>
+      <bpmn:incoming>Flow_1w1hs7g</bpmn:incoming>
       <bpmn:outgoing>Flow_1bv320r</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:callActivity id="Activity_1nraabm" name="Start Business Process" calledElement="StartBusinessProcess">
@@ -98,9 +98,29 @@
           <camunda:inputParameter name="caseEvent">NOTIFY_RPA_ON_CASE_HANDED_OFFLINE</camunda:inputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0qgvakl</bpmn:incoming>
+      <bpmn:incoming>Flow_191julc</bpmn:incoming>
       <bpmn:outgoing>Flow_1a2n9ax</bpmn:outgoing>
     </bpmn:serviceTask>
+    <bpmn:serviceTask id="DefendantResponseFullDefenceNotifyRespondentSolicitor1CC" name="Notify respondent solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1tgi30k</bpmn:incoming>
+      <bpmn:outgoing>Flow_1w1hs7g</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1w1hs7g" sourceRef="DefendantResponseFullDefenceNotifyRespondentSolicitor1CC" targetRef="DefendantResponseFullDefenceGenerateDirectionsQuestionnaire" />
+    <bpmn:serviceTask id="DefendantResponseCaseHandedOfflineNotifyRespondentSolicitor1CC" name="Notify respondent solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_HANDED_OFFLINE_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0qgvakl</bpmn:incoming>
+      <bpmn:outgoing>Flow_191julc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_191julc" sourceRef="DefendantResponseCaseHandedOfflineNotifyRespondentSolicitor1CC" targetRef="NotifyRoboticsOnCaseHandedOffline" />
     <bpmn:textAnnotation id="TextAnnotation_18hpho5">
       <bpmn:text>Case Handed Offline</bpmn:text>
     </bpmn:textAnnotation>
@@ -115,8 +135,8 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DEFENDANT_RESPONSE_PROCESS_ID">
       <bpmndi:BPMNEdge id="Flow_1a2n9ax_di" bpmnElement="Flow_1a2n9ax">
-        <di:waypoint x="850" y="180" />
-        <di:waypoint x="950" y="180" />
+        <di:waypoint x="1000" y="180" />
+        <di:waypoint x="1090" y="180" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01gz2ld_di" bpmnElement="Flow_01gz2ld">
         <di:waypoint x="188" y="300" />
@@ -131,22 +151,22 @@
         <di:waypoint x="290" y="208" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bv320r_di" bpmnElement="Flow_1bv320r">
-        <di:waypoint x="800" y="297" />
-        <di:waypoint x="910" y="297" />
-        <di:waypoint x="910" y="180" />
-        <di:waypoint x="950" y="180" />
+        <di:waypoint x="1000" y="297" />
+        <di:waypoint x="1050" y="297" />
+        <di:waypoint x="1050" y="180" />
+        <di:waypoint x="1090" y="180" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tgi30k_di" bpmnElement="Flow_1tgi30k">
-        <di:waypoint x="650" y="297" />
-        <di:waypoint x="700" y="297" />
+        <di:waypoint x="710" y="297" />
+        <di:waypoint x="760" y="297" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0jauxrx_di" bpmnElement="Flow_0jauxrx">
-        <di:waypoint x="1050" y="180" />
-        <di:waypoint x="1092" y="180" />
+        <di:waypoint x="1190" y="180" />
+        <di:waypoint x="1232" y="180" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qgvakl_di" bpmnElement="Flow_0qgvakl">
         <di:waypoint x="710" y="180" />
-        <di:waypoint x="750" y="180" />
+        <di:waypoint x="760" y="180" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01e5t4p_di" bpmnElement="Flow_01e5t4p">
         <di:waypoint x="420" y="272" />
@@ -155,15 +175,20 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17u38kw_di" bpmnElement="Flow_17u38kw">
         <di:waypoint x="445" y="297" />
-        <di:waypoint x="550" y="297" />
+        <di:waypoint x="610" y="297" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1shs5t2_di" bpmnElement="Flow_1shs5t2">
         <di:waypoint x="570" y="180" />
         <di:waypoint x="610" y="180" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="DefendantResponseFullDefenceNotifyApplicantSolicitor1">
-        <dc:Bounds x="550" y="257" width="100" height="80" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_1w1hs7g_di" bpmnElement="Flow_1w1hs7g">
+        <di:waypoint x="860" y="297" />
+        <di:waypoint x="900" y="297" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_191julc_di" bpmnElement="Flow_191julc">
+        <di:waypoint x="860" y="180" />
+        <di:waypoint x="900" y="180" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1pp6fod_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="282" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -179,29 +204,38 @@
       <bpmndi:BPMNShape id="Gateway_1q9qem9_di" bpmnElement="Gateway_1q9qem9" isMarkerVisible="true">
         <dc:Bounds x="395" y="272" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_15p049m_di" bpmnElement="Event_15p049m">
-        <dc:Bounds x="1092" y="162" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_049xhbq_di" bpmnElement="Activity_1m5szz9">
-        <dc:Bounds x="950" y="140" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_10mwnra_di" bpmnElement="DefendantResponseFullDefenceGenerateDirectionsQuestionnaire">
-        <dc:Bounds x="700" y="257" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1nraabm_di" bpmnElement="Activity_1nraabm">
         <dc:Bounds x="240" y="257" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_17h58yd_di" bpmnElement="Event_17h58yd">
         <dc:Bounds x="272" y="172" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0izbqh1_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="750" y="140" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_18hpho5_di" bpmnElement="TextAnnotation_18hpho5">
         <dc:Bounds x="370" y="110" width="100" height="40" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="TextAnnotation_0yaoqdd_di" bpmnElement="TextAnnotation_0yaoqdd">
         <dc:Bounds x="470" y="330" width="100" height="40" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_15p049m_di" bpmnElement="Event_15p049m">
+        <dc:Bounds x="1232" y="162" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_049xhbq_di" bpmnElement="Activity_1m5szz9">
+        <dc:Bounds x="1090" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_10mwnra_di" bpmnElement="DefendantResponseFullDefenceGenerateDirectionsQuestionnaire">
+        <dc:Bounds x="900" y="257" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0izbqh1_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
+        <dc:Bounds x="900" y="140" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ipbyde_di" bpmnElement="DefendantResponseFullDefenceNotifyApplicantSolicitor1">
+        <dc:Bounds x="610" y="257" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0zcb8h6_di" bpmnElement="DefendantResponseFullDefenceNotifyRespondentSolicitor1CC">
+        <dc:Bounds x="760" y="257" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d445ky_di" bpmnElement="DefendantResponseCaseHandedOfflineNotifyRespondentSolicitor1CC">
+        <dc:Bounds x="760" y="140" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1wie3up_di" bpmnElement="Event_1wie3up">
         <dc:Bounds x="272" y="239" width="36" height="36" />

--- a/src/main/resources/camunda/inform_agreed_extension_date.bpmn
+++ b/src/main/resources/camunda/inform_agreed_extension_date.bpmn
@@ -39,29 +39,35 @@
         </camunda:properties>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_18b51mb</bpmn:incoming>
+      <bpmn:incoming>Flow_14kz7pj</bpmn:incoming>
       <bpmn:outgoing>Flow_0qyhi90</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:endEvent id="Event_1520zkg">
       <bpmn:incoming>Flow_0qyhi90</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0qyhi90" sourceRef="Activity_1i1bcz2" targetRef="Event_1520zkg" />
-    <bpmn:sequenceFlow id="Flow_18b51mb" sourceRef="AgreedExtensionDateNotifyApplicantSolicitor1" targetRef="Activity_1i1bcz2" />
+    <bpmn:sequenceFlow id="Flow_18b51mb" sourceRef="AgreedExtensionDateNotifyApplicantSolicitor1" targetRef="AgreedExtensionDateNotifyRespondentSolicitor1CC" />
+    <bpmn:serviceTask id="AgreedExtensionDateNotifyRespondentSolicitor1CC" name="Notify respondent solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_18b51mb</bpmn:incoming>
+      <bpmn:outgoing>Flow_14kz7pj</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_14kz7pj" sourceRef="AgreedExtensionDateNotifyRespondentSolicitor1CC" targetRef="Activity_1i1bcz2" />
   </bpmn:process>
   <bpmn:message id="Message_1b64xfv" name="INFORM_AGREED_EXTENSION_DATE" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="INFORM_AGREED_EXTENSION_DATE_PROCESS_ID">
       <bpmndi:BPMNEdge id="Flow_18b51mb_di" bpmnElement="Flow_18b51mb">
+        <di:waypoint x="500" y="177" />
         <di:waypoint x="530" y="177" />
-        <di:waypoint x="580" y="177" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qyhi90_di" bpmnElement="Flow_0qyhi90">
-        <di:waypoint x="680" y="174" />
-        <di:waypoint x="732" y="174" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_089frwq_di" bpmnElement="Flow_089frwq">
         <di:waypoint x="370" y="177" />
-        <di:waypoint x="430" y="177" />
+        <di:waypoint x="400" y="177" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0cbpb7a_di" bpmnElement="Flow_0cbpb7a">
         <di:waypoint x="228" y="180" />
@@ -70,6 +76,14 @@
       <bpmndi:BPMNEdge id="Flow_0c23og9_di" bpmnElement="Flow_0c23og9">
         <di:waypoint x="320" y="119" />
         <di:waypoint x="320" y="85" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qyhi90_di" bpmnElement="Flow_0qyhi90">
+        <di:waypoint x="760" y="174" />
+        <di:waypoint x="792" y="174" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14kz7pj_di" bpmnElement="Flow_14kz7pj">
+        <di:waypoint x="630" y="177" />
+        <di:waypoint x="660" y="177" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0m7mqgu_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="192" y="162" width="36" height="36" />
@@ -83,14 +97,17 @@
       <bpmndi:BPMNShape id="Event_0e26gjw_di" bpmnElement="Event_0e26gjw">
         <dc:Bounds x="302" y="49" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1520zkg_di" bpmnElement="Event_1520zkg">
+        <dc:Bounds x="792" y="156" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0cx0xe8_di" bpmnElement="AgreedExtensionDateNotifyApplicantSolicitor1">
-        <dc:Bounds x="430" y="137" width="100" height="80" />
+        <dc:Bounds x="400" y="137" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1i1bcz2_di" bpmnElement="Activity_1i1bcz2">
-        <dc:Bounds x="580" y="134" width="100" height="80" />
+        <dc:Bounds x="660" y="134" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1520zkg_di" bpmnElement="Event_1520zkg">
-        <dc:Bounds x="732" y="156" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0jtsmci_di" bpmnElement="AgreedExtensionDateNotifyRespondentSolicitor1CC">
+        <dc:Bounds x="530" y="137" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qm6nf4_di" bpmnElement="Event_0qm6nf4">
         <dc:Bounds x="302" y="119" width="36" height="36" />

--- a/src/main/resources/camunda/inform_agreed_extension_date.bpmn
+++ b/src/main/resources/camunda/inform_agreed_extension_date.bpmn
@@ -22,8 +22,8 @@
     </bpmn:boundaryEvent>
     <bpmn:sequenceFlow id="Flow_0c23og9" sourceRef="Event_0qm6nf4" targetRef="Event_0e26gjw" />
     <bpmn:sequenceFlow id="Flow_0cbpb7a" sourceRef="StartEvent_1" targetRef="Activity_023yrjd" />
-    <bpmn:sequenceFlow id="Flow_089frwq" sourceRef="Activity_023yrjd" targetRef="InformAgreedExtensionDateNotifyApplicantSolicitor1" />
-    <bpmn:serviceTask id="InformAgreedExtensionDateNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+    <bpmn:sequenceFlow id="Flow_089frwq" sourceRef="Activity_023yrjd" targetRef="AgreedExtensionDateNotifyApplicantSolicitor1" />
+    <bpmn:serviceTask id="AgreedExtensionDateNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
       <bpmn:extensionElements>
         <camunda:inputOutput>
           <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE</camunda:inputParameter>
@@ -46,51 +46,51 @@
       <bpmn:incoming>Flow_0qyhi90</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0qyhi90" sourceRef="Activity_1i1bcz2" targetRef="Event_1520zkg" />
-    <bpmn:sequenceFlow id="Flow_18b51mb" sourceRef="InformAgreedExtensionDateNotifyApplicantSolicitor1" targetRef="Activity_1i1bcz2" />
+    <bpmn:sequenceFlow id="Flow_18b51mb" sourceRef="AgreedExtensionDateNotifyApplicantSolicitor1" targetRef="Activity_1i1bcz2" />
   </bpmn:process>
   <bpmn:message id="Message_1b64xfv" name="INFORM_AGREED_EXTENSION_DATE" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="INFORM_AGREED_EXTENSION_DATE_PROCESS_ID">
-      <bpmndi:BPMNEdge id="Flow_0c23og9_di" bpmnElement="Flow_0c23og9">
-        <di:waypoint x="320" y="119" />
-        <di:waypoint x="320" y="85" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0cbpb7a_di" bpmnElement="Flow_0cbpb7a">
-        <di:waypoint x="228" y="180" />
-        <di:waypoint x="270" y="180" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_089frwq_di" bpmnElement="Flow_089frwq">
-        <di:waypoint x="370" y="177" />
-        <di:waypoint x="430" y="177" />
+      <bpmndi:BPMNEdge id="Flow_18b51mb_di" bpmnElement="Flow_18b51mb">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="580" y="177" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0qyhi90_di" bpmnElement="Flow_0qyhi90">
         <di:waypoint x="680" y="174" />
         <di:waypoint x="732" y="174" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18b51mb_di" bpmnElement="Flow_18b51mb">
-        <di:waypoint x="530" y="177" />
-        <di:waypoint x="580" y="177" />
+      <bpmndi:BPMNEdge id="Flow_089frwq_di" bpmnElement="Flow_089frwq">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="Activity_023yrjd_di" bpmnElement="Activity_023yrjd">
-        <dc:Bounds x="270" y="137" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0e26gjw_di" bpmnElement="Event_0e26gjw">
-        <dc:Bounds x="302" y="49" width="36" height="36" />
-      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="Flow_0cbpb7a_di" bpmnElement="Flow_0cbpb7a">
+        <di:waypoint x="228" y="180" />
+        <di:waypoint x="270" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c23og9_di" bpmnElement="Flow_0c23og9">
+        <di:waypoint x="320" y="119" />
+        <di:waypoint x="320" y="85" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0m7mqgu_di" bpmnElement="StartEvent_1">
         <dc:Bounds x="192" y="162" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="198" y="205" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_023yrjd_di" bpmnElement="Activity_023yrjd">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0e26gjw_di" bpmnElement="Event_0e26gjw">
+        <dc:Bounds x="302" y="49" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cx0xe8_di" bpmnElement="AgreedExtensionDateNotifyApplicantSolicitor1">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1i1bcz2_di" bpmnElement="Activity_1i1bcz2">
         <dc:Bounds x="580" y="134" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1520zkg_di" bpmnElement="Event_1520zkg">
         <dc:Bounds x="732" y="156" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cx0xe8_di" bpmnElement="InformAgreedExtensionDateNotifyApplicantSolicitor1">
-        <dc:Bounds x="430" y="137" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qm6nf4_di" bpmnElement="Event_0qm6nf4">
         <dc:Bounds x="302" y="119" width="36" height="36" />

--- a/src/main/resources/camunda/inform_agreed_extension_date.bpmn
+++ b/src/main/resources/camunda/inform_agreed_extension_date.bpmn
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0d4bcaj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
+  <bpmn:process id="INFORM_AGREED_EXTENSION_DATE_PROCESS_ID" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0cbpb7a</bpmn:outgoing>
+      <bpmn:messageEventDefinition id="MessageEventDefinition_1hupx5h" messageRef="Message_1b64xfv" />
+    </bpmn:startEvent>
+    <bpmn:callActivity id="Activity_023yrjd" name="Start Business Process" calledElement="StartBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:in variables="all" />
+        <camunda:out variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0cbpb7a</bpmn:incoming>
+      <bpmn:outgoing>Flow_089frwq</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_0e26gjw">
+      <bpmn:incoming>Flow_0c23og9</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:boundaryEvent id="Event_0qm6nf4" name="Abort" attachedToRef="Activity_023yrjd">
+      <bpmn:outgoing>Flow_0c23og9</bpmn:outgoing>
+      <bpmn:errorEventDefinition id="ErrorEventDefinition_02pyvny" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_0c23og9" sourceRef="Event_0qm6nf4" targetRef="Event_0e26gjw" />
+    <bpmn:sequenceFlow id="Flow_0cbpb7a" sourceRef="StartEvent_1" targetRef="Activity_023yrjd" />
+    <bpmn:sequenceFlow id="Flow_089frwq" sourceRef="Activity_023yrjd" targetRef="InformAgreedExtensionDateNotifyApplicantSolicitor1" />
+    <bpmn:serviceTask id="InformAgreedExtensionDateNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_089frwq</bpmn:incoming>
+      <bpmn:outgoing>Flow_18b51mb</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:callActivity id="Activity_1i1bcz2" name="End Business Process" calledElement="EndBusinessProcess">
+      <bpmn:extensionElements>
+        <camunda:properties>
+          <camunda:property name="variables" value="all" />
+        </camunda:properties>
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_18b51mb</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qyhi90</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:endEvent id="Event_1520zkg">
+      <bpmn:incoming>Flow_0qyhi90</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0qyhi90" sourceRef="Activity_1i1bcz2" targetRef="Event_1520zkg" />
+    <bpmn:sequenceFlow id="Flow_18b51mb" sourceRef="InformAgreedExtensionDateNotifyApplicantSolicitor1" targetRef="Activity_1i1bcz2" />
+  </bpmn:process>
+  <bpmn:message id="Message_1b64xfv" name="INFORM_AGREED_EXTENSION_DATE" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="INFORM_AGREED_EXTENSION_DATE_PROCESS_ID">
+      <bpmndi:BPMNEdge id="Flow_0c23og9_di" bpmnElement="Flow_0c23og9">
+        <di:waypoint x="320" y="119" />
+        <di:waypoint x="320" y="85" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cbpb7a_di" bpmnElement="Flow_0cbpb7a">
+        <di:waypoint x="228" y="180" />
+        <di:waypoint x="270" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_089frwq_di" bpmnElement="Flow_089frwq">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qyhi90_di" bpmnElement="Flow_0qyhi90">
+        <di:waypoint x="680" y="174" />
+        <di:waypoint x="732" y="174" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18b51mb_di" bpmnElement="Flow_18b51mb">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="580" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_023yrjd_di" bpmnElement="Activity_023yrjd">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0e26gjw_di" bpmnElement="Event_0e26gjw">
+        <dc:Bounds x="302" y="49" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0m7mqgu_di" bpmnElement="StartEvent_1">
+        <dc:Bounds x="192" y="162" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="198" y="205" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1i1bcz2_di" bpmnElement="Activity_1i1bcz2">
+        <dc:Bounds x="580" y="134" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1520zkg_di" bpmnElement="Event_1520zkg">
+        <dc:Bounds x="732" y="156" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cx0xe8_di" bpmnElement="InformAgreedExtensionDateNotifyApplicantSolicitor1">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0qm6nf4_di" bpmnElement="Event_0qm6nf4">
+        <dc:Bounds x="302" y="119" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="336" y="100" width="27" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/camunda/notify_claim.bpmn
+++ b/src/main/resources/camunda/notify_claim.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="NOTIFY_CLAIM" isExecutable="true">
     <bpmn:startEvent id="Event_0t2zome" name="Start">
       <bpmn:outgoing>Flow_1if0h68</bpmn:outgoing>
@@ -13,7 +13,7 @@
       <bpmn:extensionElements>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1qlh0ym</bpmn:incoming>
+      <bpmn:incoming>Flow_1j6s22p</bpmn:incoming>
       <bpmn:outgoing>Flow_1hce35l</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:callActivity id="Activity_0y089q8" name="Start Business Process" calledElement="StartBusinessProcess">
@@ -42,14 +42,32 @@
       <bpmn:incoming>Flow_1qffyiy</bpmn:incoming>
       <bpmn:outgoing>Flow_1qlh0ym</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1qlh0ym" sourceRef="NotifyDefendantSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1qlh0ym" sourceRef="NotifyDefendantSolicitor1" targetRef="NotifyApplicantSolicitor1CC" />
     <bpmn:sequenceFlow id="Flow_1qffyiy" sourceRef="Activity_0y089q8" targetRef="NotifyDefendantSolicitor1" />
+    <bpmn:serviceTask id="NotifyApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_ISSUE_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1qlh0ym</bpmn:incoming>
+      <bpmn:outgoing>Flow_1j6s22p</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1j6s22p" sourceRef="NotifyApplicantSolicitor1CC" targetRef="Activity_0wretog" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="NOTIFY_DEFENDANT_OF_CLAIM" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmn:error id="Error_1237qii" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="NOTIFY_CLAIM">
+      <bpmndi:BPMNEdge id="Flow_1qffyiy_di" bpmnElement="Flow_1qffyiy">
+        <di:waypoint x="330" y="250" />
+        <di:waypoint x="360" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qlh0ym_di" bpmnElement="Flow_1qlh0ym">
+        <di:waypoint x="460" y="250" />
+        <di:waypoint x="490" y="250" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1if0h68_di" bpmnElement="Flow_1if0h68">
         <di:waypoint x="188" y="250" />
         <di:waypoint x="230" y="250" />
@@ -59,16 +77,12 @@
         <di:waypoint x="280" y="158" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
-        <di:waypoint x="650" y="250" />
-        <di:waypoint x="692" y="250" />
+        <di:waypoint x="720" y="250" />
+        <di:waypoint x="762" y="250" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qlh0ym_di" bpmnElement="Flow_1qlh0ym">
-        <di:waypoint x="500" y="250" />
-        <di:waypoint x="550" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qffyiy_di" bpmnElement="Flow_1qffyiy">
-        <di:waypoint x="330" y="250" />
-        <di:waypoint x="400" y="250" />
+      <bpmndi:BPMNEdge id="Flow_1j6s22p_di" bpmnElement="Flow_1j6s22p">
+        <di:waypoint x="590" y="250" />
+        <di:waypoint x="620" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
         <dc:Bounds x="152" y="232" width="36" height="36" />
@@ -82,14 +96,17 @@
       <bpmndi:BPMNShape id="Event_1mtqud7_di" bpmnElement="Event_1mtqud7">
         <dc:Bounds x="262" y="122" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1co096w_di" bpmnElement="NotifyDefendantSolicitor1">
-        <dc:Bounds x="400" y="210" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
+        <dc:Bounds x="762" y="232" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
-        <dc:Bounds x="550" y="210" width="100" height="80" />
+        <dc:Bounds x="620" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
-        <dc:Bounds x="692" y="232" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1co096w_di" bpmnElement="NotifyDefendantSolicitor1">
+        <dc:Bounds x="360" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1yfkaai_di" bpmnElement="NotifyApplicantSolicitor1CC">
+        <dc:Bounds x="490" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0o3sg3o_di" bpmnElement="Event_0o3sg3o">
         <dc:Bounds x="262" y="192" width="36" height="36" />

--- a/src/main/resources/camunda/notify_claim_details.bpmn
+++ b/src/main/resources/camunda/notify_claim_details.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="NOTIFY_CLAIM_DETAILS" isExecutable="true">
     <bpmn:startEvent id="Event_0t2zome" name="Start">
       <bpmn:outgoing>Flow_1if0h68</bpmn:outgoing>
@@ -13,7 +13,7 @@
       <bpmn:extensionElements>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_1qlh0ym</bpmn:incoming>
+      <bpmn:incoming>Flow_17j65bw</bpmn:incoming>
       <bpmn:outgoing>Flow_1hce35l</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:callActivity id="Activity_0y089q8" name="Start Business Process" calledElement="StartBusinessProcess">
@@ -42,8 +42,18 @@
       <bpmn:incoming>Flow_1qffyiy</bpmn:incoming>
       <bpmn:outgoing>Flow_1qlh0ym</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1qlh0ym" sourceRef="NotifyClaimDetailsRespondentSolicitor1" targetRef="Activity_0wretog" />
+    <bpmn:sequenceFlow id="Flow_1qlh0ym" sourceRef="NotifyClaimDetailsRespondentSolicitor1" targetRef="NotifyClaimDetailsApplicantSolicitor1CC" />
     <bpmn:sequenceFlow id="Flow_1qffyiy" sourceRef="Activity_0y089q8" targetRef="NotifyClaimDetailsRespondentSolicitor1" />
+    <bpmn:serviceTask id="NotifyClaimDetailsApplicantSolicitor1CC" name="Notify applicant solicitor 1 (CC)" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DETAILS_CC</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1qlh0ym</bpmn:incoming>
+      <bpmn:outgoing>Flow_17j65bw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_17j65bw" sourceRef="NotifyClaimDetailsApplicantSolicitor1CC" targetRef="Activity_0wretog" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="NOTIFY_DEFENDANT_OF_CLAIM_DETAILS" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
@@ -52,11 +62,11 @@
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="NOTIFY_CLAIM_DETAILS">
       <bpmndi:BPMNEdge id="Flow_1qffyiy_di" bpmnElement="Flow_1qffyiy">
         <di:waypoint x="330" y="250" />
-        <di:waypoint x="400" y="250" />
+        <di:waypoint x="370" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qlh0ym_di" bpmnElement="Flow_1qlh0ym">
-        <di:waypoint x="500" y="250" />
-        <di:waypoint x="550" y="250" />
+        <di:waypoint x="470" y="250" />
+        <di:waypoint x="490" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1if0h68_di" bpmnElement="Flow_1if0h68">
         <di:waypoint x="188" y="250" />
@@ -67,8 +77,12 @@
         <di:waypoint x="280" y="158" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_1hce35l">
-        <di:waypoint x="650" y="250" />
-        <di:waypoint x="692" y="250" />
+        <di:waypoint x="710" y="250" />
+        <di:waypoint x="752" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17j65bw_di" bpmnElement="Flow_17j65bw">
+        <di:waypoint x="590" y="250" />
+        <di:waypoint x="610" y="250" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_0t2zome">
         <dc:Bounds x="152" y="232" width="36" height="36" />
@@ -76,20 +90,23 @@
           <dc:Bounds x="158" y="275" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
-        <dc:Bounds x="692" y="232" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
-        <dc:Bounds x="550" y="210" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0y089q8_di" bpmnElement="Activity_0y089q8">
         <dc:Bounds x="230" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1mtqud7_di" bpmnElement="Event_1mtqud7">
         <dc:Bounds x="262" y="122" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_0r8yo0r">
+        <dc:Bounds x="752" y="232" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_0wretog">
+        <dc:Bounds x="610" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1co096w_di" bpmnElement="NotifyClaimDetailsRespondentSolicitor1">
-        <dc:Bounds x="400" y="210" width="100" height="80" />
+        <dc:Bounds x="370" y="210" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1hizfxh_di" bpmnElement="NotifyClaimDetailsApplicantSolicitor1CC">
+        <dc:Bounds x="490" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0o3sg3o_di" bpmnElement="Event_0o3sg3o">
         <dc:Bounds x="262" y="192" width="36" height="36" />

--- a/src/main/resources/camunda/take_case_offline.bpmn
+++ b/src/main/resources/camunda/take_case_offline.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0rn46su" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.5.0">
   <bpmn:process id="TAKE_CASE_OFFLINE" isExecutable="true">
     <bpmn:startEvent id="Event_StartClaimTakenOffline" name="Start">
       <bpmn:outgoing>Flow_NextStartBusinessProcess</bpmn:outgoing>
@@ -13,7 +13,7 @@
       <bpmn:extensionElements>
         <camunda:in variables="all" />
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_NextEndBusinessProcess</bpmn:incoming>
+      <bpmn:incoming>Flow_0uljtsx</bpmn:incoming>
       <bpmn:outgoing>Flow_NextEndEvent</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:callActivity id="Activity_StartBusinessProcess" name="Start Business Process" calledElement="StartBusinessProcess">
@@ -43,15 +43,39 @@
       <bpmn:incoming>Flow_NextNotifyRpa</bpmn:incoming>
       <bpmn:outgoing>Flow_NextEndBusinessProcess</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_NextEndBusinessProcess" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="Activity_EndBusinessProcess" />
+    <bpmn:sequenceFlow id="Flow_NextEndBusinessProcess" sourceRef="NotifyRoboticsOnCaseHandedOffline" targetRef="TakeCaseOfflineNotifyRespondentSolicitor1" />
+    <bpmn:serviceTask id="TakeCaseOfflineNotifyRespondentSolicitor1" name="Notify respondent solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_NextEndBusinessProcess</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hq815y</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1hq815y" sourceRef="TakeCaseOfflineNotifyRespondentSolicitor1" targetRef="TakeCaseOfflineNotifyApplicantSolicitor1" />
+    <bpmn:serviceTask id="TakeCaseOfflineNotifyApplicantSolicitor1" name="Notify applicant solicitor 1" camunda:type="external" camunda:topic="processCaseEvent">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="caseEvent">NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hq815y</bpmn:incoming>
+      <bpmn:outgoing>Flow_0uljtsx</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0uljtsx" sourceRef="TakeCaseOfflineNotifyApplicantSolicitor1" targetRef="Activity_EndBusinessProcess" />
   </bpmn:process>
   <bpmn:message id="Message_0slk3de" name="TAKE_CASE_OFFLINE" />
   <bpmn:error id="Error_0t2ju7k" name="StartBusinessAbort" errorCode="ABORT" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="TAKE_CASE_OFFLINE">
+      <bpmndi:BPMNEdge id="Flow_09loe5v_di" bpmnElement="Flow_NextEndBusinessProcess">
+        <di:waypoint x="470" y="210" />
+        <di:waypoint x="500" y="210" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14aod2o_di" bpmnElement="Flow_NextNotifyRpa">
         <di:waypoint x="330" y="210" />
-        <di:waypoint x="430" y="210" />
+        <di:waypoint x="370" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08myj65_di" bpmnElement="Flow_NextStartBusinessProcess">
         <di:waypoint x="188" y="210" />
@@ -62,12 +86,16 @@
         <di:waypoint x="280" y="118" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hce35l_di" bpmnElement="Flow_NextEndEvent">
-        <di:waypoint x="740" y="210" />
-        <di:waypoint x="802" y="210" />
+        <di:waypoint x="880" y="210" />
+        <di:waypoint x="912" y="210" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09loe5v_di" bpmnElement="Flow_NextEndBusinessProcess">
-        <di:waypoint x="530" y="210" />
+      <bpmndi:BPMNEdge id="Flow_1hq815y_di" bpmnElement="Flow_1hq815y">
+        <di:waypoint x="600" y="210" />
         <di:waypoint x="640" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uljtsx_di" bpmnElement="Flow_0uljtsx">
+        <di:waypoint x="740" y="210" />
+        <di:waypoint x="780" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_1m02c2o_di" bpmnElement="Event_StartClaimTakenOffline">
         <dc:Bounds x="152" y="192" width="36" height="36" />
@@ -75,20 +103,26 @@
           <dc:Bounds x="158" y="235" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
-        <dc:Bounds x="802" y="192" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0emdthr_di" bpmnElement="Activity_StartBusinessProcess">
         <dc:Bounds x="230" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1nsmt51_di" bpmnElement="Event_1nsmt51">
         <dc:Bounds x="262" y="82" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
-        <dc:Bounds x="640" y="170" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_08ndbvb_di" bpmnElement="NotifyRoboticsOnCaseHandedOffline">
-        <dc:Bounds x="430" y="170" width="100" height="80" />
+        <dc:Bounds x="370" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8yo0r_di" bpmnElement="Event_EndClaimTakenOffline">
+        <dc:Bounds x="912" y="192" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1x5rl4x_di" bpmnElement="Activity_EndBusinessProcess">
+        <dc:Bounds x="780" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0lrzkzm_di" bpmnElement="TakeCaseOfflineNotifyRespondentSolicitor1">
+        <dc:Bounds x="500" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1huplho_di" bpmnElement="TakeCaseOfflineNotifyApplicantSolicitor1">
+        <dc:Bounds x="640" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1fn0bf1_di" bpmnElement="Event_1fn0bf1">
         <dc:Bounds x="262" y="152" width="36" height="36" />

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AcknowledgeClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AcknowledgeClaimTest.java
@@ -44,6 +44,14 @@ class AcknowledgeClaimTest extends BpmnBaseTest {
         assertCompleteExternalTask(notification, PROCESS_CASE_EVENT, NOTIFY_APPLICANT_SOLICITOR_1,
                                    NOTIFICATION_ACTIVITY_ID);
 
+        //complete the CC notification to respondent
+        notification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(notification,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_ACKNOWLEDGEMENT_CC",
+                                   "AcknowledgeClaimNotifyRespondentSolicitor1CC"
+        );
+
         //end business process
         ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
         completeBusinessProcess(endBusinessProcess);
@@ -58,8 +66,6 @@ class AcknowledgeClaimTest extends BpmnBaseTest {
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
 
         //fail the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AcknowledgeClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AcknowledgeClaimTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.unspec.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.variable.VariableMap;
-import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AddDefendantLitigationFriendTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AddDefendantLitigationFriendTest.java
@@ -8,20 +8,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-class RetryRpaNotificationTest extends BpmnBaseTest {
+class AddDefendantLitigationFriendTest extends BpmnBaseTest {
 
-    public static final String MESSAGE_NAME = "RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
-    public static final String PROCESS_ID = "RETRY_RPA_NOTIFICATION_PROCESS_ID";
+    public static final String MESSAGE_NAME = "ADD_DEFENDANT_LITIGATION_FRIEND";
+    public static final String PROCESS_ID = "ADD_DEFENDANT_LITIGATION_FRIEND";
 
-    public static final String RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE = "RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
-    private static final String ACTIVITY_ID = "RetryRoboticsNotification";
-
-    public RetryRpaNotificationTest() {
-        super("retry_rpa_notification.bpmn", "RETRY_RPA_NOTIFICATION_PROCESS_ID");
+    public AddDefendantLitigationFriendTest() {
+        super("add_defendant_litigation_friend.bpmn", PROCESS_ID);
     }
 
     @Test
-    void shouldSuccessfullyCompleteRetryRpaNotification() {
+    void shouldSuccessfullyCompleteNotifyClaim_whenCalled() {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -30,12 +27,27 @@ class RetryRpaNotificationTest extends BpmnBaseTest {
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY
+        );
 
-        //complete the notification
+        //complete the notification to respondent
         ExternalTask notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(notificationTask, PROCESS_CASE_EVENT,
-                                   RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE, ACTIVITY_ID
+        assertCompleteExternalTask(notificationTask,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_LITIGATION_FRIEND_ADDED",
+                                   "LitigationFriendAddedNotifyApplicantSolicitor1"
+        );
+
+        //complete the CC notification to applicant
+        notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(notificationTask,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_RESPONDENT_SOLICITOR1_FOR_LITIGATION_FRIEND_ADDED",
+                                   "LitigationFriendAddedNotifyRespondentSolicitor1"
         );
 
         //end business process

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AddDefendantLitigationFriendTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/AddDefendantLitigationFriendTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.unspec.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.variable.VariableMap;
-import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/CaseProceedsInCasemanTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/CaseProceedsInCasemanTest.java
@@ -8,22 +8,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-class DismissClaimTest extends BpmnBaseTest {
+class CaseProceedsInCasemanTest extends BpmnBaseTest {
 
-    public static final String MESSAGE_NAME = "DISMISS_CLAIM";
-    public static final String PROCESS_ID = "DISMISS_CLAIM";
+    public static final String MESSAGE_NAME = "CASE_PROCEEDS_IN_CASEMAN";
+    public static final String PROCESS_ID = "CASE_PROCEEDS_IN_CASEMAN";
 
-    public static final String NOTIFY_RESPONDENT_SOLICITOR_1 = "NOTIFY_RESPONDENT_SOLICITOR1_CLAIM_DISMISSED";
-    public static final String RESPONDENT_SOLICITOR_1_ACTIVITY_ID = "ClaimDismissedNotifyRespondentSolicitor1";
-    public static final String NOTIFY_APPLICANT_SOLICITOR_1 = "NOTIFY_APPLICANT_SOLICITOR1_CLAIM_DISMISSED";
-    public static final String APPLICANT_SOLICITOR_1_ACTIVITY_ID = "ClaimDismissedNotifyApplicantSolicitor1";
-
-    public DismissClaimTest() {
-        super("claim_dismissed.bpmn", "DISMISS_CLAIM");
+    public CaseProceedsInCasemanTest() {
+        super("case_proceeds_in_caseman.bpmn", PROCESS_ID);
     }
 
     @Test
-    void shouldSuccessfullyCompleteDismissClaim() {
+    void shouldSuccessfullyCompleteNotifyClaim_whenCalled() {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -32,24 +27,27 @@ class DismissClaimTest extends BpmnBaseTest {
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
-
-        //complete the notification to respondent solicitor 1
-        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            respondentNotification,
-            PROCESS_CASE_EVENT,
-            NOTIFY_RESPONDENT_SOLICITOR_1,
-            RESPONDENT_SOLICITOR_1_ACTIVITY_ID
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY
         );
 
-        //complete the notification to applicant solicitor 1
+        //complete the notification to respondent
+        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(respondentNotification,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN",
+                                   "CaseProceedsInCasemanNotifyRespondentSolicitor1"
+        );
+
+        //complete the notification to applicant
         ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            applicantNotification,
-            PROCESS_CASE_EVENT,
-            NOTIFY_APPLICANT_SOLICITOR_1,
-            APPLICANT_SOLICITOR_1_ACTIVITY_ID
+        assertCompleteExternalTask(applicantNotification,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_PROCEEDS_IN_CASEMAN",
+                                   "CaseProceedsInCasemanNotifyApplicantSolicitor1"
         );
 
         //end business process
@@ -66,8 +64,6 @@ class DismissClaimTest extends BpmnBaseTest {
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
 
         //fail the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/CaseProceedsInCasemanTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/CaseProceedsInCasemanTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.unspec.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.variable.VariableMap;
-import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimDismissedTest.java
@@ -30,7 +30,13 @@ class ClaimDismissedTest extends BpmnBaseTest {
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
 
         //complete the notification to respondent
         ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
@@ -57,7 +63,6 @@ class ClaimDismissedTest extends BpmnBaseTest {
         assertNoExternalTasksLeft();
     }
 
-
     @Test
     void shouldSuccessfullyCompleteDismissClaim_whenPastClaimNotificationDeadline() {
         //assert process has started
@@ -71,7 +76,13 @@ class ClaimDismissedTest extends BpmnBaseTest {
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
 
         //complete the notification to respondent
         ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
@@ -98,7 +109,6 @@ class ClaimDismissedTest extends BpmnBaseTest {
         assertNoExternalTasksLeft();
     }
 
-
     @Test
     void shouldSuccessfullyCompleteDismissClaim_whenPastClaimDetailsNotificationDeadline() {
         //assert process has started
@@ -112,7 +122,13 @@ class ClaimDismissedTest extends BpmnBaseTest {
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
 
         //complete the notification to respondent
         ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimDismissedTest.java
@@ -18,7 +18,81 @@ class ClaimDismissedTest extends BpmnBaseTest {
     }
 
     @Test
-    void shouldSuccessfullyCompleteDismissClaim_whenPastClaimDismissedDeadline() {
+    void shouldNotifyApplicantSolicitor_whenPastClaimNotificationDeadline() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE");
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            applicantNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED",
+            "ClaimDismissedNotifyApplicantSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+    @Test
+    void shouldNotifyApplicantSolicitor_whenPastClaimDetailsNotificationDeadline() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE");
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY,
+            variables
+        );
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            applicantNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED",
+            "ClaimDismissedNotifyApplicantSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+    @Test
+    void shouldNotifyBothParties_whenPastClaimDismissedDeadline() {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -43,8 +117,8 @@ class ClaimDismissedTest extends BpmnBaseTest {
         assertCompleteExternalTask(
             respondentNotification,
             PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE",
-            "ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1"
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED",
+            "ClaimDismissedNotifyRespondentSolicitor1"
         );
 
         //complete the notification to applicant
@@ -52,100 +126,8 @@ class ClaimDismissedTest extends BpmnBaseTest {
         assertCompleteExternalTask(
             applicantNotification,
             PROCESS_CASE_EVENT,
-            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE",
-            "ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1"
-        );
-
-        //end business process
-        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
-        completeBusinessProcess(endBusinessProcess);
-
-        assertNoExternalTasksLeft();
-    }
-
-    @Test
-    void shouldSuccessfullyCompleteDismissClaim_whenPastClaimNotificationDeadline() {
-        //assert process has started
-        assertFalse(processInstance.isEnded());
-
-        //assert message start event
-        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
-        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE");
-
-        //complete the start business process
-        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(
-            startBusiness,
-            START_BUSINESS_TOPIC,
-            START_BUSINESS_EVENT,
-            START_BUSINESS_ACTIVITY,
-            variables
-        );
-
-        //complete the notification to respondent
-        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            respondentNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE",
-            "ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1"
-        );
-
-        //complete the notification to applicant
-        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            applicantNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE",
-            "ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1"
-        );
-
-        //end business process
-        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
-        completeBusinessProcess(endBusinessProcess);
-
-        assertNoExternalTasksLeft();
-    }
-
-    @Test
-    void shouldSuccessfullyCompleteDismissClaim_whenPastClaimDetailsNotificationDeadline() {
-        //assert process has started
-        assertFalse(processInstance.isEnded());
-
-        //assert message start event
-        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
-        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE");
-
-        //complete the start business process
-        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(
-            startBusiness,
-            START_BUSINESS_TOPIC,
-            START_BUSINESS_EVENT,
-            START_BUSINESS_ACTIVITY,
-            variables
-        );
-
-        //complete the notification to respondent
-        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            respondentNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE",
-            "ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1"
-        );
-
-        //complete the notification to applicant
-        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            applicantNotification,
-            PROCESS_CASE_EVENT,
-            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE",
-            "ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1"
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED",
+            "ClaimDismissedNotifyApplicantSolicitor1"
         );
 
         //end business process

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimDismissedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimDismissedTest.java
@@ -1,0 +1,156 @@
+package uk.gov.hmcts.reform.unspec.bpmn;
+
+import org.camunda.bpm.engine.externaltask.ExternalTask;
+import org.camunda.bpm.engine.variable.VariableMap;
+import org.camunda.bpm.engine.variable.Variables;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class ClaimDismissedTest extends BpmnBaseTest {
+
+    public static final String MESSAGE_NAME = "DISMISS_CLAIM";
+    public static final String PROCESS_ID = "DISMISS_CLAIM";
+
+    public ClaimDismissedTest() {
+        super("claim_dismissed.bpmn", "DISMISS_CLAIM");
+    }
+
+    @Test
+    void shouldSuccessfullyCompleteDismissClaim_whenPastClaimDismissedDeadline() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE");
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables);
+
+        //complete the notification to respondent
+        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            respondentNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE",
+            "ClaimDismissedPastClaimDismissedDeadlineNotifyRespondentSolicitor1"
+        );
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            applicantNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DISMISSED_DEADLINE",
+            "ClaimDismissedPastClaimDismissedDeadlineNotifyApplicantSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+
+    @Test
+    void shouldSuccessfullyCompleteDismissClaim_whenPastClaimNotificationDeadline() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE");
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables);
+
+        //complete the notification to respondent
+        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            respondentNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE",
+            "ClaimDismissedPastClaimNotificationDeadlineNotifyRespondentSolicitor1"
+        );
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            applicantNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_NOTIFICATION_DEADLINE",
+            "ClaimDismissedPastClaimNotificationDeadlineNotifyApplicantSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+
+    @Test
+    void shouldSuccessfullyCompleteDismissClaim_whenPastClaimDetailsNotificationDeadline() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        VariableMap variables = Variables.createVariables();
+        variables.putValue("flowState", "MAIN.CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE");
+
+        //complete the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY, variables);
+
+        //complete the notification to respondent
+        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            respondentNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE",
+            "ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyRespondentSolicitor1"
+        );
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            applicantNotification,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_DISMISSED_PAST_CLAIM_DETAILS_NOTIFICATION_DEADLINE",
+            "ClaimDismissedPastClaimDetailsNotificationDeadlineNotifyApplicantSolicitor1"
+        );
+
+        //end business process
+        ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
+        completeBusinessProcess(endBusinessProcess);
+
+        assertNoExternalTasksLeft();
+    }
+
+    @Test
+    void shouldAbort_whenStartBusinessProcessThrowsAnError() {
+        //assert process has started
+        assertFalse(processInstance.isEnded());
+
+        //assert message start event
+        assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
+
+        //fail the start business process
+        ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
+        assertFailExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+
+        assertNoExternalTasksLeft();
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimantResponseTest.java
@@ -10,13 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 class ClaimantResponseTest extends BpmnBaseTest {
 
-    private static final String RESPONDENT_SOLICITOR_1
-        = "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_TRANSFERRED_TO_LOCAL_COURT";
     private static final String PROCEED_OFFLINE_EVENT = "PROCEEDS_IN_HERITAGE_SYSTEM";
-    private static final String RESPONDENT_ACTIVITY = "ClaimantResponseNotifyRespondentSolicitor1";
-    private static final String APPLICANT_SOLICITOR_1
-        = "NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_TRANSFERRED_TO_LOCAL_COURT";
-    private static final String APPLICANT_ACTIVITY = "ClaimantResponseNotifyApplicantSolicitor1";
     private static final String GENERATE_DIRECTIONS_QUESTIONNAIRE = "GENERATE_DIRECTIONS_QUESTIONNAIRE";
     private static final String GENERATE_DIRECTIONS_QUESTIONNAIRE_ACTIVITY_ID
         = "ClaimantResponseGenerateDirectionsQuestionnaire";
@@ -58,26 +52,6 @@ class ClaimantResponseTest extends BpmnBaseTest {
             PROCESS_CASE_EVENT,
             PROCEED_OFFLINE_EVENT,
             PROCEED_OFFLINE_FOR_RESPONSE_TO_DEFENCE_ACTIVITY_ID,
-            variables
-        );
-
-        //complete the notification
-        ExternalTask forRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            forRespondent,
-            PROCESS_CASE_EVENT,
-            RESPONDENT_SOLICITOR_1,
-            RESPONDENT_ACTIVITY,
-            variables
-        );
-
-        //complete the notification
-        ExternalTask forApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            forApplicant,
-            PROCESS_CASE_EVENT,
-            APPLICANT_SOLICITOR_1,
-            APPLICANT_ACTIVITY,
             variables
         );
 
@@ -155,26 +129,6 @@ class ClaimantResponseTest extends BpmnBaseTest {
             PROCESS_CASE_EVENT,
             PROCEED_OFFLINE_EVENT,
             PROCEED_OFFLINE_FOR_RESPONSE_TO_DEFENCE_ACTIVITY_ID,
-            variables
-        );
-
-        //complete the notification
-        ExternalTask forRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            forRespondent,
-            PROCESS_CASE_EVENT,
-            RESPONDENT_SOLICITOR_1,
-            RESPONDENT_ACTIVITY,
-            variables
-        );
-
-        //complete the notification
-        ExternalTask forApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(
-            forApplicant,
-            PROCESS_CASE_EVENT,
-            APPLICANT_SOLICITOR_1,
-            APPLICANT_ACTIVITY,
             variables
         );
 

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/ClaimantResponseTest.java
@@ -91,6 +91,24 @@ class ClaimantResponseTest extends BpmnBaseTest {
             variables
         );
 
+        //complete the notification to respondent
+        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyRespondent,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED",
+            "ClaimantConfirmsToProceedNotifyRespondentSolicitor1"
+        );
+
+        //complete the CC notification to applicant
+        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyApplicant,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_TO_PROCEED_CC",
+            "ClaimantConfirmsToProceedNotifyApplicantSolicitor1CC"
+        );
+
         //complete the Robotics notification
         ExternalTask forRobotics = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
@@ -158,6 +176,24 @@ class ClaimantResponseTest extends BpmnBaseTest {
             APPLICANT_SOLICITOR_1,
             APPLICANT_ACTIVITY,
             variables
+        );
+
+        //complete the notification to respondent
+        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyRespondent,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED",
+            "ClaimantConfirmsNotToProceedNotifyRespondentSolicitor1"
+        );
+
+        //complete the CC notification to applicant
+        ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyApplicant,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIMANT_CONFIRMS_NOT_TO_PROCEED_CC",
+            "ClaimantConfirmsNotToProceedNotifyApplicantSolicitor1CC"
         );
 
         //complete the Robotics notification

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/CreateClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/CreateClaimTest.java
@@ -123,6 +123,15 @@ class CreateClaimTest extends BpmnBaseTest {
                 variables
             );
 
+            //complete the notification
+            ExternalTask notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+            assertCompleteExternalTask(
+                notificationTask,
+                PROCESS_CASE_EVENT,
+                "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_CONTINUING_ONLINE",
+                "CreateClaimContinuingOnlineNotifyApplicantSolicitor1"
+            );
+
             //end business process
             ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
             completeBusinessProcess(endBusinessProcess);
@@ -422,6 +431,15 @@ class CreateClaimTest extends BpmnBaseTest {
                 ISSUE_CLAIM_EVENT,
                 ISSUE_CLAIM_ACTIVITY_ID,
                 variables
+            );
+
+            //complete the notification
+            ExternalTask notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+            assertCompleteExternalTask(
+                notificationTask,
+                PROCESS_CASE_EVENT,
+                "NOTIFY_APPLICANT_SOLICITOR1_FOR_CLAIM_CONTINUING_ONLINE",
+                "CreateClaimContinuingOnlineNotifyApplicantSolicitor1"
             );
 
             //end business process

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/DefendantResponseTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/DefendantResponseTest.java
@@ -138,13 +138,22 @@ class DefendantResponseTest extends BpmnBaseTest {
             FULL_DEFENCE_RESPONSE_ACTIVITY_ID
         );
 
-        //complete the notification to respondent
+        //complete the notification to applicant
         ExternalTask notifyApplicant = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
             notifyApplicant,
             PROCESS_CASE_EVENT,
             FULL_DEFENCE_NOTIFY_APPLICANT_SOLICITOR_1,
             FULL_DEFENCE_NOTIFICATION_ACTIVITY_ID
+        );
+
+        //complete the CC notification to respondent
+        ExternalTask notifyRespondent = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(
+            notifyRespondent,
+            PROCESS_CASE_EVENT,
+            "NOTIFY_APPLICANT_SOLICITOR1_FOR_DEFENDANT_RESPONSE_CC",
+            "DefendantResponseFullDefenceNotifyRespondentSolicitor1CC"
         );
 
         //complete the document generation
@@ -170,8 +179,6 @@ class DefendantResponseTest extends BpmnBaseTest {
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
 
         //fail the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/InformAgreedExtensionDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/InformAgreedExtensionDateTest.java
@@ -8,20 +8,17 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
-class RetryRpaNotificationTest extends BpmnBaseTest {
+class InformAgreedExtensionDateTest extends BpmnBaseTest {
 
-    public static final String MESSAGE_NAME = "RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
-    public static final String PROCESS_ID = "RETRY_RPA_NOTIFICATION_PROCESS_ID";
+    public static final String MESSAGE_NAME = "INFORM_AGREED_EXTENSION_DATE";
+    public static final String PROCESS_ID = "INFORM_AGREED_EXTENSION_DATE_PROCESS_ID";
 
-    public static final String RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE = "RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE";
-    private static final String ACTIVITY_ID = "RetryRoboticsNotification";
-
-    public RetryRpaNotificationTest() {
-        super("retry_rpa_notification.bpmn", "RETRY_RPA_NOTIFICATION_PROCESS_ID");
+    public InformAgreedExtensionDateTest() {
+        super("inform_agreed_extension_date.bpmn", PROCESS_ID);
     }
 
     @Test
-    void shouldSuccessfullyCompleteRetryRpaNotification() {
+    void shouldSuccessfullyCompleteNotifyClaim_whenCalled() {
         //assert process has started
         assertFalse(processInstance.isEnded());
 
@@ -30,12 +27,27 @@ class RetryRpaNotificationTest extends BpmnBaseTest {
 
         //complete the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);
-        assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
+        assertCompleteExternalTask(
+            startBusiness,
+            START_BUSINESS_TOPIC,
+            START_BUSINESS_EVENT,
+            START_BUSINESS_ACTIVITY
+        );
 
-        //complete the notification
+        //complete the notification to applicant
         ExternalTask notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
-        assertCompleteExternalTask(notificationTask, PROCESS_CASE_EVENT,
-                                   RETRY_NOTIFY_RPA_ON_CASE_HANDED_OFFLINE, ACTIVITY_ID
+        assertCompleteExternalTask(notificationTask,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE",
+                                   "AgreedExtensionDateNotifyApplicantSolicitor1"
+        );
+
+        //complete the CC notification to respondent
+        notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(notificationTask,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_AGREED_EXTENSION_DATE_CC",
+                                   "AgreedExtensionDateNotifyRespondentSolicitor1CC"
         );
 
         //end business process

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/InformAgreedExtensionDateTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/InformAgreedExtensionDateTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.unspec.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.variable.VariableMap;
-import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/NotifyClaimDetailsTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/NotifyClaimDetailsTest.java
@@ -49,6 +49,14 @@ class NotifyClaimDetailsTest extends BpmnBaseTest {
                                    NOTIFY_RESPONDENT_SOLICITOR_1_CLAIM_DETAILS_ACTIVITY_ID
         );
 
+        //complete the CC notification
+        notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(notificationTask,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_DETAILS_CC",
+                                   "NotifyClaimDetailsApplicantSolicitor1CC"
+        );
+
         //end business process
         ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
         completeBusinessProcess(endBusinessProcess);
@@ -63,8 +71,6 @@ class NotifyClaimDetailsTest extends BpmnBaseTest {
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
 
         //fail the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/NotifyClaimTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/NotifyClaimTest.java
@@ -49,6 +49,14 @@ class NotifyClaimTest extends BpmnBaseTest {
                                    NOTIFY_RESPONDENT_SOLICITOR_1_CLAIM_ISSUE_ACTIVITY_ID
         );
 
+        //complete the CC notification
+        notificationTask = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(notificationTask,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CLAIM_ISSUE_CC",
+                                   "NotifyApplicantSolicitor1CC"
+        );
+
         //end business process
         ExternalTask endBusinessProcess = assertNextExternalTask(END_BUSINESS_PROCESS);
         completeBusinessProcess(endBusinessProcess);
@@ -63,8 +71,6 @@ class NotifyClaimTest extends BpmnBaseTest {
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
 
         //fail the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/RetryRpaNotificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/RetryRpaNotificationTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.unspec.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.variable.VariableMap;
-import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/TakeCaseOfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/TakeCaseOfflineTest.java
@@ -33,12 +33,28 @@ class TakeCaseOfflineTest extends BpmnBaseTest {
         assertCompleteExternalTask(startBusiness, START_BUSINESS_TOPIC, START_BUSINESS_EVENT, START_BUSINESS_ACTIVITY);
 
         //complete the RPA notification
-        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        ExternalTask rpaNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
         assertCompleteExternalTask(
-            respondentNotification,
+            rpaNotification,
             PROCESS_CASE_EVENT,
             NOTIFY_RPA_ON_CASE_HANDED_OFFLINE,
             NOTIFY_RPA_ON_CASE_HANDED_OFFLINE_ACTIVITY_ID
+        );
+
+        //complete the notification to respondent
+        ExternalTask respondentNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(respondentNotification,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_RESPONDENT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE",
+                                   "TakeCaseOfflineNotifyRespondentSolicitor1"
+        );
+
+        //complete the notification to applicant
+        ExternalTask applicantNotification = assertNextExternalTask(PROCESS_CASE_EVENT);
+        assertCompleteExternalTask(applicantNotification,
+                                   PROCESS_CASE_EVENT,
+                                   "NOTIFY_APPLICANT_SOLICITOR1_FOR_CASE_TAKEN_OFFLINE",
+                                   "TakeCaseOfflineNotifyApplicantSolicitor1"
         );
 
         //end business process
@@ -55,8 +71,6 @@ class TakeCaseOfflineTest extends BpmnBaseTest {
 
         //assert message start event
         assertThat(getProcessDefinitionByMessage(MESSAGE_NAME).getKey()).isEqualTo(PROCESS_ID);
-
-        VariableMap variables = Variables.createVariables();
 
         //fail the start business process
         ExternalTask startBusiness = assertNextExternalTask(START_BUSINESS_TOPIC);

--- a/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/TakeCaseOfflineTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/unspec/bpmn/TakeCaseOfflineTest.java
@@ -1,8 +1,6 @@
 package uk.gov.hmcts.reform.unspec.bpmn;
 
 import org.camunda.bpm.engine.externaltask.ExternalTask;
-import org.camunda.bpm.engine.variable.VariableMap;
-import org.camunda.bpm.engine.variable.Variables;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/CMC-1442

### Change description ###

- Create claim (added notification for claim continuing online on represented / registered respondent)

<img width="1344" alt="create claim" src="https://user-images.githubusercontent.com/58216515/116974617-50874600-acb6-11eb-88ba-484abf949d3e.png">

- Notify claim (added CC notification)

<img width="719" alt="notify claim" src="https://user-images.githubusercontent.com/58216515/116384008-5640df80-a80f-11eb-95bf-56eb76c79782.png">

- Notify claim details (added CC notification)

<img width="697" alt="notify claim details" src="https://user-images.githubusercontent.com/58216515/116384107-6fe22700-a80f-11eb-9b2e-9b539ffc9271.png">

- Acknowledge claim (added CC notification)
<img width="836" alt="acknowledge claim" src="https://user-images.githubusercontent.com/58216515/116380682-188e8780-a80c-11eb-8abd-0b3d276082fb.png">

- Inform agreed extension date (new business process)

<img width="764" alt="inform agreed extension date" src="https://user-images.githubusercontent.com/58216515/116383911-35788a00-a80f-11eb-9a76-79d527ade15e.png">

- Defendant response (added CC notification for full defence)

<img width="1289" alt="defendant response" src="https://user-images.githubusercontent.com/58216515/116974657-5b41db00-acb6-11eb-895f-3f551ade929f.png">

- Claimant response (added confirms to proceed / not to proceed notifications with CC notifications)

<img width="1221" alt="claimant response" src="https://user-images.githubusercontent.com/58216515/117170408-e78cf480-adc1-11eb-8341-3b50104477ab.png">

- Case proceeds in caseman (new business process)

<img width="730" alt="case proceeds in caseman" src="https://user-images.githubusercontent.com/58216515/116381711-10831780-a80d-11eb-813d-f568cdc37607.png">

- Take case offline (added applicant and respondent notifications)

<img width="865" alt="take case offline" src="https://user-images.githubusercontent.com/58216515/116384429-bdf72a80-a80f-11eb-8552-7ee12a37e5e7.png">

- Claim dismissed (added different routes with different notifications depending on unmet deadline)

<img width="947" alt="claim dismissed" src="https://user-images.githubusercontent.com/58216515/116381902-3d372f00-a80d-11eb-931e-3f52ced3e4ce.png">

- Add defendant litigation friend (new business process)
<img width="757" alt="add defendant litigation friend" src="https://user-images.githubusercontent.com/58216515/116381607-f8ab9380-a80c-11eb-9f49-9400e3d77a44.png">

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
